### PR TITLE
feat: block 컴포넌트와 placeholder 부분 합치기

### DIFF
--- a/src/app/(main)/note/[id]/_components/note-content/block-button.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block-button.tsx
@@ -8,7 +8,6 @@ const blockBtnContainer = css({
   left: '-3rem',
   display: 'flex',
   flexDirection: 'row',
-  pt: '0.2rem',
 });
 
 const blockBtn = css({

--- a/src/app/(main)/note/[id]/_components/note-content/block.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block.tsx
@@ -12,11 +12,10 @@ interface IBlockComponent {
   setBlockList: (blockList: ITextBlock[]) => void;
   isTyping: boolean;
   setIsTyping: (isTyping: boolean) => void;
-  isFocused: boolean[];
-  setIsFocused: (isFocused: boolean[]) => void;
 }
 
-const noteContentContainer = css({
+const blockDiv = css({
+  position: 'relative',
   boxSizing: 'border-box',
   display: 'flex',
   flex: '1',
@@ -26,8 +25,16 @@ const noteContentContainer = css({
   outline: 'none',
   overflowY: 'hidden',
   flexShrink: 0,
-  resize: 'none',
-  alignItems: 'center',
+
+  '&:focus:empty::before': {
+    position: 'absolute',
+    top: '0',
+    left: '0',
+    content: 'attr(data-placeholder)',
+    color: 'gray',
+    fontSize: 'md',
+    pointerEvents: 'none',
+  },
 });
 
 const Block = memo(
@@ -39,8 +46,6 @@ const Block = memo(
     setBlockList,
     isTyping: _isTyping,
     setIsTyping,
-    isFocused,
-    setIsFocused,
   }: IBlockComponent) => {
     const handleInput = (e: React.FormEvent<HTMLDivElement>, i: number) => {
       setIsTyping(true);
@@ -48,18 +53,10 @@ const Block = memo(
       const target = e.currentTarget;
       updatedBlockList[i].children[0].content = target.textContent || '';
       setBlockList(updatedBlockList);
-    };
-
-    const handleFocus = (i: number) => {
-      const newFocusState = [...isFocused];
-      newFocusState[i] = true;
-      setIsFocused(newFocusState);
-    };
-
-    const handleBlur = (i: number) => {
-      const newFocusState = [...isFocused];
-      newFocusState[i] = false;
-      setIsFocused(newFocusState);
+      if (blockRef.current[index]?.innerText.trim() === '') {
+        // eslint-disable-next-line no-param-reassign
+        blockRef.current[index].innerHTML = '';
+      }
     };
 
     const splitBlock = (i: number) => {
@@ -154,10 +151,9 @@ const Block = memo(
         tabIndex={0}
         contentEditable
         suppressContentEditableWarning
-        className={noteContentContainer}
+        data-placeholder="글을 작성하거나 AI를 사용하려면 '스페이스' 키를, 명령어를 사용하려면 '/' 키를누르세요."
+        className={blockDiv}
         onInput={e => handleInput(e, index)}
-        onFocus={() => handleFocus(index)}
-        onBlur={() => handleBlur(index)}
         onKeyDown={event => handleKeyDown(event, index)}
         ref={element => {
           // eslint-disable-next-line no-param-reassign

--- a/src/app/(main)/note/[id]/_components/note-content/block.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block.tsx
@@ -3,6 +3,7 @@ import { css } from '@/../styled-system/css';
 
 import { ITextBlock } from '@/types/block-type';
 import keyName from '@/constants/key-name';
+import placeholder from '@/constants/placeholder';
 
 interface IBlockComponent {
   block: ITextBlock;
@@ -151,9 +152,9 @@ const Block = memo(
         tabIndex={0}
         contentEditable
         suppressContentEditableWarning
-        data-placeholder="글을 작성하거나 AI를 사용하려면 '스페이스' 키를, 명령어를 사용하려면 '/' 키를누르세요."
+        data-placeholder={placeholder.block}
         className={blockDiv}
-        onInput={e => handleInput(e, index)}
+        onInput={event => handleInput(event, index)}
         onKeyDown={event => handleKeyDown(event, index)}
         ref={element => {
           // eslint-disable-next-line no-param-reassign

--- a/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
@@ -11,19 +11,6 @@ const blockContainer = css({
   flexDirection: 'row',
 });
 
-const focusTextStyle = css({
-  position: 'absolute',
-  top: '0.1rem',
-  color: 'gray',
-  fontSize: 'md',
-  pointerEvents: 'none',
-});
-
-const wrapper = css({
-  position: 'relative',
-  verticalAlign: 'middle',
-});
-
 const NoteContent = () => {
   const [blockList, setBlockList] = useState<ITextBlock[]>([
     {
@@ -47,7 +34,6 @@ const NoteContent = () => {
   ]);
 
   const [isTyping, setIsTyping] = useState(false);
-  const [isFocused, setIsFocused] = useState<boolean[]>([false]);
   const [isHover, setIsHover] = useState<boolean[]>([]);
 
   const blockRef = useRef<(HTMLDivElement | null)[]>([]);
@@ -67,31 +53,22 @@ const NoteContent = () => {
   return (
     <>
       {blockList.map((block, index) => (
-        <div className={wrapper} key={block.id}>
-          <div
-            className={blockContainer}
-            onMouseEnter={() => handleMouseEnter(index)}
-            onMouseLeave={() => handleMouseLeave(index)}
-          >
-            {isHover[index] && <BlockButton />}
-            {isFocused[index] && block.children[0].content?.trim() === '' && (
-              <div className={focusTextStyle}>
-                글을 작성하거나 AI를 사용하려면 '스페이스' 키를, 명령어를 사용하려면 '/' 키를
-                누르세요.
-              </div>
-            )}
-            <Block
-              block={block}
-              index={index}
-              blockRef={blockRef}
-              blockList={blockList}
-              setBlockList={setBlockList}
-              isTyping={isTyping}
-              setIsTyping={setIsTyping}
-              isFocused={isFocused}
-              setIsFocused={setIsFocused}
-            />
-          </div>
+        <div
+          key={block.id}
+          className={blockContainer}
+          onMouseEnter={() => handleMouseEnter(index)}
+          onMouseLeave={() => handleMouseLeave(index)}
+        >
+          {isHover[index] && <BlockButton />}
+          <Block
+            index={index}
+            block={block}
+            blockRef={blockRef}
+            blockList={blockList}
+            setBlockList={setBlockList}
+            isTyping={isTyping}
+            setIsTyping={setIsTyping}
+          />
         </div>
       ))}
     </>

--- a/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
@@ -7,6 +7,7 @@ import Block from './block';
 import BlockButton from './block-button';
 
 const blockContainer = css({
+  position: 'relative',
   display: 'flex',
   flexDirection: 'row',
 });

--- a/src/constants/placeholder.ts
+++ b/src/constants/placeholder.ts
@@ -1,0 +1,5 @@
+const placeholder = {
+  block: "글을 작성하거나 AI를 사용하려면 '스페이스' 키를, 명령어를 사용하려면 '/' 키를누르세요.",
+};
+
+export default placeholder;


### PR DESCRIPTION
## 📝 PR Description

- block 컴포넌트와 placeholder 부분 합치기

---

## 🔍 Changes Made

- useState를 이용해 block 컴포넌트 위에 placeholder를 띄워주던 것을 css의 focus, empty, before 등 가상 요소와 가상 클래스를 이용해 구현하였습니다.
- placeholder에 들어갈 문자열을 상수로 빼주었습니다.

---

**설명**: 이 항목에서는 코드의 주요 변경 사항을 나열하여 리뷰어가 코드 수정의 목적을 쉽게 파악할 수
있도록 합니다. 변경된 주요 로직이나 UI 수정 사항이 있다면 구체적으로 설명합니다.

---
