### PR TITLE
feat: 줄 바꿈 된 상태에서도 잘 동작하도록 블록 분할 로직 변경

### DIFF
--- a/src/app/(main)/note/[id]/_components/note-content/block.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block.tsx
@@ -1,4 +1,4 @@
-import { useState, memo, useEffect } from 'react';
+import { useState, memo } from 'react';
 import { css } from '@/../styled-system/css';
 
 import { ITextBlock } from '@/types/block-type';
@@ -60,19 +60,15 @@ const Block = memo(
       }
     };
 
-    useEffect(() => {
-      console.log('useEffect', blockList);
-    }, [blockList]);
-
     const splitBlock = (i: number) => {
       const selection = window.getSelection();
       if (!selection || selection.rangeCount === 0) return;
 
       const range = selection.getRangeAt(0);
-      const container = range.startContainer; // 현재 커서가 위치한 노드
-      const offset = range.startOffset; // 커서가 해당 노드 내에서 몇 번째 위치인지
-      const parent = blockRef.current[i]; // contentEditable 전체 영역
-      const children = parent?.childNodes; // contentEditable 내 자식 노드들
+      const container = range.startContainer;
+      const offset = range.startOffset;
+      const parent = blockRef.current[i];
+      const children = parent?.childNodes;
       const childNodes = Array.from(children as NodeListOf<HTMLElement>);
 
       const beforeBlock = Array.from(childNodes as HTMLElement[])
@@ -212,10 +208,6 @@ const Block = memo(
         setIsTyping(false);
         setKey(Math.random());
         splitBlock(i);
-      }
-
-      if (e.key === keyName.enter && e.shiftKey) {
-        console.log(blockList);
       }
 
       if (e.key === keyName.backspace) {

--- a/src/app/(main)/note/[id]/page.tsx
+++ b/src/app/(main)/note/[id]/page.tsx
@@ -11,7 +11,7 @@ const container = css({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  gap: 'huge',
+  gap: 'large',
 });
 
 const noteContainer = css({

--- a/src/types/block-type.ts
+++ b/src/types/block-type.ts
@@ -5,7 +5,7 @@ export interface ITextBlock {
 }
 
 interface ITextBlockChild {
-  type: 'text' | 'codeBlock' | 'h1' | 'h2' | 'h3';
+  type: 'text' | 'codeBlock' | 'h1' | 'h2' | 'h3' | 'br';
   style: IBlockStyle;
   content: string | null;
 }


### PR DESCRIPTION
## 📝 PR Description

- 줄 바꿈 된 상태에서도 잘 동작하도록 블록 분할 로직 변경

---

## 🔍 Changes Made

- block 내용 보여줄 때 map을 이용해 children 모두 보여주기
- 블록 분할 로직 변경
- contentEditable div에 key값을 넣어 리렌더링 될 때마다 key 값 바꿔주기

---

**설명**: 이 항목에서는 코드의 주요 변경 사항을 나열하여 리뷰어가 코드 수정의 목적을 쉽게 파악할 수
있도록 합니다. 변경된 주요 로직이나 UI 수정 사항이 있다면 구체적으로 설명합니다.

---

## 🔄 Extra Comments

- range의 startContainer를 이용해 줄바꿈 한 상태에서 현재 커서가 몇 번째 노드에 위치해있는지 확인했습니다.
- 현재 노드의 커서 위치를 기준으로 나누어서 이전 블록과 다음 블록에 넣었습니다.
- 이제 블록에 여러 노드들이 들어가게 되어서 기존에 `block.children[0].content`로 띄워주던 것을 map을 이용해 띄어주도록 변경했습니다.

<br />

- 블록 분할 시 리렌더링이 될 때 이전 DOM 조작으로 인한 내용이 남아있는 문제가 발생했습니다.
- 이 값을 강제로 비워주기 위해서 contentEditable div에 key 값을 주어 리렌더링이 될 때마다 key 값을 바꿔서 비워지게 했습니다.

---

**설명**: 이 PR과 관련된 추가적인 정보를 작성하여 리뷰어가 작업의 맥락을 이해하고, 리뷰에 필요한
내용을 쉽게 참고할 수 있도록 합니다. 이를 통해 PR의 내용을 명확히 전달할 수 있습니다.

---

## 📷 Demo


https://github.com/user-attachments/assets/91df85f7-b359-4546-8a58-9b6edf2b4d43


---

**설명**: UI 변경 사항이 포함된 경우, 변경된 화면을 시각적으로 보여주기 위해 스크린샷이나 동영상을
첨부하면 도움이 됩니다. 리뷰어는 화면 변경 사항을 바로 확인할 수 있어 코드 리뷰가 더 효과적입니다.

---
