### PR TITLE
feat: 줄 바꿈 관련 로직들 구현하기

### DIFF
--- a/src/app/(main)/@modal/(.)search-modal/_component/searchbar.tsx
+++ b/src/app/(main)/@modal/(.)search-modal/_component/searchbar.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 
 import SearchIcon from '@/icons/search-icon';
 import CancleIcon from '@/icons/cancle-icon';
+import placeholder from '@/constants/placeholder';
 
 const searchBar = css({
   height: '3rem',
@@ -57,7 +58,7 @@ const SearchBar = () => {
         type="text"
         value={inputValue}
         onChange={handleChange}
-        placeholder="Search Page or Keyword"
+        placeholder={placeholder.searchModal}
       />
       <div className={cancleButton} onClick={clearInput}>
         <CancleIcon color="black" />

--- a/src/app/(main)/_components/sidebar/sidebar.tsx
+++ b/src/app/(main)/_components/sidebar/sidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { css } from '@/../styled-system/css';
 
 import ProfileCard from './profile/profile-card';

--- a/src/app/(main)/note/[id]/_components/line-info/line-info.tsx
+++ b/src/app/(main)/note/[id]/_components/line-info/line-info.tsx
@@ -2,6 +2,7 @@ import { css } from '@/../styled-system/css';
 
 const lineInfoContainer = css({
   height: '6rem',
+  minHeight: '6rem',
   display: 'flex',
 });
 

--- a/src/app/(main)/note/[id]/_components/note-content/block.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block.tsx
@@ -83,11 +83,73 @@ const Block = memo(
         updatedBlockList[i].children.splice(currentChildNodeIndex + 1, 1);
       }
 
+      if (
+        currentChildNodeIndex !== -1 &&
+        updatedBlockList[i].children[currentChildNodeIndex].type === 'br'
+      ) {
+        if (currentChildNodeIndex !== childNodes.length - 1) {
+          // "안녕"<br><br>"하세요" 이 구조에서는 중간의 빈 줄에 text 입력 시 <br>과 <br> 사이에 textNode가 생성되어야함
+          updatedBlockList[i].children.splice(currentChildNodeIndex, 0, {
+            type: 'text',
+            style: {
+              fontStyle: 'normal',
+              fontWeight: 'regular',
+              color: 'black',
+              backgroundColor: 'white',
+              width: 'auto',
+              height: 'auto',
+            },
+            content: '',
+          });
+        } else {
+          // "안녕하세요"<br><br> 이 구조에서는 마지막 <br>이 textNode로 변경되어야함
+          updatedBlockList[i].children.splice(currentChildNodeIndex, 1, {
+            type: 'text',
+            style: {
+              fontStyle: 'normal',
+              fontWeight: 'regular',
+              color: 'black',
+              backgroundColor: 'white',
+              width: 'auto',
+              height: 'auto',
+            },
+            content: '',
+          });
+        }
+      }
+
       // 블록에 입력된 내용을 blockList에 반영하는 로직
       updatedBlockList[i].children[
         currentChildNodeIndex === -1 ? offset : currentChildNodeIndex
       ].content =
         currentChildNodeIndex !== -1 ? childNodes[currentChildNodeIndex].textContent || '' : '';
+
+      // 블록 중간에 빈 textNode가 생기면 삭제하고, 마지막 줄에 빈 textNode 생기면 <br>로 변경
+      const updatedChildList = updatedBlockList[i].children
+        .map((child, idx) => {
+          if (child.type === 'text' && child.content === '') {
+            if (idx === updatedBlockList[i].children.length - 1) {
+              return {
+                type: 'br' as 'br',
+                style: {
+                  fontStyle: 'normal',
+                  fontWeight: 'regular',
+                  color: 'black',
+                  backgroundColor: 'white',
+                  width: 'auto',
+                  height: 'auto',
+                },
+                content: '',
+              };
+            }
+
+            return '';
+          }
+          return child;
+        })
+        .filter(child => child !== '');
+
+      updatedBlockList[i].children = updatedChildList;
 
       setBlockList(updatedBlockList);
       prevChildNodesLength.current = childNodes.length;

--- a/src/app/(main)/note/[id]/_components/note-content/block.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block.tsx
@@ -1,4 +1,4 @@
-import { useState, memo, useEffect } from 'react';
+import { useState, memo } from 'react';
 import { css } from '@/../styled-system/css';
 
 import { ITextBlock } from '@/types/block-type';
@@ -73,6 +73,10 @@ const Block = memo(
       if (!target.childNodes[currentIndex + 1]) {
         updatedBlockList[i].children.splice(currentIndex + 1, 1);
       }
+
+      updatedBlockList[i].children[currentIndex].content =
+        childNodes[currentIndex].textContent || '';
+
       setBlockList(updatedBlockList);
     };
 
@@ -197,7 +201,6 @@ const Block = memo(
     };
 
     const splitLine = (i: number) => {
-      console.log(blockList);
       const selection = window.getSelection();
       if (!selection) return;
 
@@ -218,7 +221,7 @@ const Block = memo(
 
           const updatedChildren = [
             ...newChildren.slice(0, parentBlockIndex),
-            textBefore && {
+            {
               type: 'text' as 'text',
               style: {
                 fontStyle: 'normal',
@@ -228,7 +231,7 @@ const Block = memo(
                 width: 'auto',
                 height: 'auto',
               },
-              content: textBefore || '',
+              content: textBefore || '.',
             },
             {
               type: 'br' as 'br',
@@ -242,7 +245,7 @@ const Block = memo(
               },
               content: '',
             },
-            textAfter && {
+            {
               type: 'text' as 'text',
               style: {
                 fontStyle: 'normal',
@@ -252,7 +255,7 @@ const Block = memo(
                 width: 'auto',
                 height: 'auto',
               },
-              content: textAfter || '',
+              content: textAfter || '.',
             },
             ...newChildren.slice(parentBlockIndex + 1),
           ];
@@ -260,7 +263,7 @@ const Block = memo(
           const updatedBlockList = [...blockList];
           updatedBlockList[i] = {
             ...updatedBlockList[i],
-            children: updatedChildren.filter(item => item !== '') as ITextBlock['children'],
+            children: updatedChildren,
           };
 
           setBlockList(updatedBlockList);
@@ -269,7 +272,7 @@ const Block = memo(
         container.nodeType === Node.ELEMENT_NODE &&
         (container as Element).tagName === 'SPAN'
       ) {
-        // TODO: span 태그일 때 처리  (현재 미구현)
+        // TODO: span 태그일 때 처리
       }
     };
 
@@ -327,17 +330,13 @@ const Block = memo(
           return;
         }
 
-        console.log(cursorPosition);
-
         if (cursorPosition === 0) {
           e.preventDefault();
           setIsTyping(false);
           setKey(Math.random());
-          // console.log(1);
           if (parentBlockIndex <= 0) {
             mergeBlock(i);
           } else if (parentBlockIndex > 0) {
-            // console.log(1);
             mergeLine(i, parentBlockIndex);
           }
         }

--- a/src/app/(main)/note/[id]/_components/note-content/block.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block.tsx
@@ -56,6 +56,15 @@ const Block = memo(
       setIsTyping(true);
       const updatedBlockList = [...blockList];
       const target = e.currentTarget;
+
+      const selection = window.getSelection();
+      if (!selection || selection.rangeCount === 0) return;
+
+      const range = selection.getRangeAt(0);
+      const container = range.startContainer;
+      const offset = range.startOffset;
+
+      console.log(target.childNodes);
       updatedBlockList[i].children[0].content = target.textContent || '';
       setBlockList(updatedBlockList);
       if (blockRef.current[index]?.innerText.trim() === '') {
@@ -81,10 +90,14 @@ const Block = memo(
         .map((node, idx) => {
           if (idx === childNodes.indexOf(container as HTMLElement)) {
             const newNode = document.createTextNode(node.textContent?.slice(0, offset) || '');
+            if (newNode.textContent === '') {
+              return;
+            }
             return newNode;
           }
           return node;
-        });
+        })
+        .filter(node => node != null);
 
       const afterBlock = childNodes
         .filter((_node, idx) => {
@@ -93,10 +106,14 @@ const Block = memo(
         .map((node, idx) => {
           if (idx === 0) {
             const newNode = document.createTextNode(node.textContent?.slice(offset) || '');
+            if (newNode.textContent === '') {
+              return;
+            }
             return newNode;
           }
           return node;
-        });
+        })
+        .filter(node => node != null);
 
       const updatedBlockList = [...blockList];
 

--- a/src/app/(main)/note/[id]/_components/note-header/note-cover.tsx
+++ b/src/app/(main)/note/[id]/_components/note-header/note-cover.tsx
@@ -14,6 +14,7 @@ const coverContainer = css({
   top: '0.5rem',
   width: '100%',
   height: '17.5rem',
+  minHeight: '17.5rem',
   zIndex: 1,
   pt: '1rem',
   pr: '1rem',

--- a/src/app/(main)/note/[id]/_components/note-header/note-header.tsx
+++ b/src/app/(main)/note/[id]/_components/note-header/note-header.tsx
@@ -22,7 +22,7 @@ const IconContainer = css({
   fontSize: 'xl',
   display: 'flex',
   alignItems: 'center',
-  justifyContent: 'start',
+  justifyContent: 'center',
   cursor: 'pointer',
   userSelect: 'none',
   borderRadius: '0.5rem',

--- a/src/app/(main)/note/[id]/_components/note-header/title.tsx
+++ b/src/app/(main)/note/[id]/_components/note-header/title.tsx
@@ -1,5 +1,7 @@
 import { css } from '@/../styled-system/css';
 
+import placeholder from '@/constants/placeholder';
+
 const titleFont = css({
   fontSize: 'lg',
   fontWeight: 'bold',
@@ -12,7 +14,7 @@ const titleFont = css({
 });
 
 const Title = () => {
-  return <input className={titleFont} placeholder="새 페이지" />;
+  return <input className={titleFont} placeholder={placeholder.noteTitle} />;
 };
 
 export default Title;

--- a/src/constants/key-name.ts
+++ b/src/constants/key-name.ts
@@ -2,6 +2,10 @@ const keyName = {
   enter: 'Enter',
   backspace: 'Backspace',
   slash: '/',
+  arrowLeft: 'ArrowLeft',
+  arrowRight: 'ArrowRight',
+  arrowUp: 'ArrowUp',
+  arrowDown: 'ArrowDown',
 };
 
 export default keyName;

--- a/src/constants/placeholder.ts
+++ b/src/constants/placeholder.ts
@@ -1,5 +1,7 @@
 const placeholder = {
   block: "글을 작성하거나 AI를 사용하려면 '스페이스' 키를, 명령어를 사용하려면 '/' 키를누르세요.",
+  noteTitle: '새 페이지',
+  searchModal: 'Search Page or Keyword',
 };
 
 export default placeholder;

--- a/src/types/block-type.ts
+++ b/src/types/block-type.ts
@@ -5,7 +5,7 @@ export interface ITextBlock {
 }
 
 interface ITextBlockChild {
-  type: 'text' | 'codeBlock' | 'h1' | 'h2' | 'h3' | 'br';
+  type: 'text' | 'span' | 'br';
   style: IBlockStyle;
   content: string | null;
 }


### PR DESCRIPTION
## 📝 PR Description

- 줄 바꿈 관련 로직들 구현하기

---

## 🔍 Changes Made

- shift + enter 시 기본 동작 막고 줄바꿈 되도록 splitLine 함수를 만들어 주었습니다.
- 줄 바꿈 후 2번 째 줄 이상에서 커서를 맨 앞에 두고 백스페이스를 누를 때 기본 동작도 막고, 줄이 합쳐질 수 있도록 mergeLine 함수를 만들어 주었습니다.
- text 입력 시 상태 업데이트를 할 때 blockList의 children에 자식 노드 인덱스에 맞게 input 값 넣어주었습니다.
- 줄 바꿈이 된 상태에서의 블록 나누기/합치기가 잘되도록 블록 나누기/합치기 로직도 수정했습니다.
- 줄 합치기/나누기, 블록 합치기/나누기를 할 때 자식 노드가 span일 때도 되도록 span일 때 로직을 추가해 주었습니다.
- 이 외에 여러 예외 상황들을 처리해주었습니다.

---

**설명**: 이 항목에서는 코드의 주요 변경 사항을 나열하여 리뷰어가 코드 수정의 목적을 쉽게 파악할 수
있도록 합니다. 변경된 주요 로직이나 UI 수정 사항이 있다면 구체적으로 설명합니다.

---

## 🔄 Extra Comments

- 블록을 합치거나 나눌 때 말고, 하나의 블록 내에서 줄을 합치거나 나눌 때에도 상태에 반영되게 하기 위해서 줄 바꿈 로직을 splitLine, mergeLine 함수를 만들어 커스텀 해주었습니다.
  - span을 처리하기 위해서도 줄바꿈 로직을 커스텀 해야 됨
- 줄 바꿈을 통해 하나의 블럭이 여러 자식 노드들을 가질 수 있게 되어서, 입력값도 올바른 자식에 넣어 주는 등의 로직이 필요해 졌습니다.
  - 나중에 bold, codeBlock 등 블록 안에 다른 자식 노드들이 생성되기 위해서도 필요함

<br>

- 위를 구현하면서 여러 예외상황들이 나와 이를 최대한 다 처리해 주었습니다.

### 블록의 자식노드 하나의 입력값이 모두 지워지면 focus 된 자식 노드가 이전 노드로 바로 넘어가 버리는 문제

-  줄바꿈이 없는 상태에서는 `"안녕""하세요"` 이렇게 두 개의 자식 노드가 있을 때, "하세요" 중 마지막으로 "하"가 지워지는 순간 바로 focus가 "안녕"으로 넘어가서 blockList에 저장할 때는 "하"가 지워진것이 반영이 안됩니다.
- 이를 해결하기 위해 글자가 입력될 때마다 입력 되기 전 자식 노드의 수를 기억하고 있다가, 자식 수가 줄어들면 자식 하나가 다 지워진 것으로 판단해서 그 때 focus 되어있는 자식 다음 인덱스의 자식을 삭제해주었습니다.
 
### focus가 `<br>`로 되어있으면, 현재 contaienr가 자식 노드가 아니라 부모인 contentEditable div로 변하는 문제

- 줄바꿈이 있는 상태에서 `"안녕"<br><br>"하세요"` 이렇게 네 개의 자식 노드가 있을 때, `<br>`에 focus를 한 채로 줄바꿈이나 줄합치기를 하려고 하면 `<br>`이 아니라 부모인 contentEditable div에 focus가 현재 몇 번째 줄에 있는지 알 수 없습니다.
- 이를 해결하기 위해 focus가 contentEditable div에 가게 되면, container를 이용해 현재 focus 된 자식 노드를 찾아서 몇번째 줄에 있는지 찾는 대신, offset을 이용해서 현재 몇 번째 줄에 있는지를 찾았습니다.

### 중복 줄바꿈
- 중복 줄바꿈을 위해 `<br>`에 커서가 위치한 상태에서 shift + enter 시 `<br>`을 하나씩 추가해 주었습니다.
- 글과 글 사이가 아닌 글의 맨 뒤에서 줄바꿈을 할때에는 `<br>`이 두개가 필요하고 계속해서 중복 줄바꿈을 이어 갈 때는 `<br>`이 하나씩만 필요해서 글의 맨 뒤에서 처음 줄바꿈일떄는 `<br>`을 두개 넣어주었습니다.

### 줄바꿈 된 상태에서 블록 나누기/합치기

- 한 줄의 맨 앞에 커서를 두고 블록 나눌 때 이전 블록 맨 뒤에 `<br>`을 추가해주어야 합니다.
- 빈 줄에서 블록 나눌 때 다음 블록 맨 앞에 `<br>`을 추가해주어야 합니다.

### 줄 바꿈 된 상태에서 빈 문자열을 가진 자식노드에 대해 DOM과 상태에 저장된 값 일치하게 하기

- 줄바꿈 된 상태에서 한줄을 다 지우면 DOM에서는 그냥 그 자식이 사라지는데, blockList에는 ""인 textNode로 변해서 이를 없애주는 로직을 추가해주었습니다.
  - 마지막 줄이 지워질 때는 없어지는 것이 아니라, `<br>`로 변해야 해서 같이 추가해 주었습니다.
- 줄바꿈 된 상태에서 한줄이 다 지워지면, `"안녕"<br><br>"하세요"` 형태가 되는데 이 때 가운데 빈 줄에 글씨를 쓰면 `<br>`이 textNode로 바뀌는 것이 아니라 `<br>`과 `<br>` 사이에 textNode가 들어가도록 하는 로직을 추가해주었습니다.
  - `"안녕"<br><br>` 이런 구조처럼 마지막 `<br>`이 변경되는 상황에서는 `<br>`과 `<br>` 사이에 textNode를 넣는것이 아니라 마지막 `<br>`을 textNode로 대체해주었습니다.

---

**설명**: 이 PR과 관련된 추가적인 정보를 작성하여 리뷰어가 작업의 맥락을 이해하고, 리뷰에 필요한
내용을 쉽게 참고할 수 있도록 합니다. 이를 통해 PR의 내용을 명확히 전달할 수 있습니다.

---

## 📷 Demo


https://github.com/user-attachments/assets/afe78e69-2bc5-4610-9397-82f46440b2f0



---

**설명**: UI 변경 사항이 포함된 경우, 변경된 화면을 시각적으로 보여주기 위해 스크린샷이나 동영상을
첨부하면 도움이 됩니다. 리뷰어는 화면 변경 사항을 바로 확인할 수 있어 코드 리뷰가 더 효과적입니다.

---
