### PR TITLE
Feat : note header api 연동

### DIFF
--- a/src/apis/note-header.ts
+++ b/src/apis/note-header.ts
@@ -1,0 +1,18 @@
+import getInstance from '.';
+
+export const editIcon = async (noteId: string, selectedIcon: string | null) => {
+  const instance = await getInstance();
+  await instance.patch(
+    `/documents/${noteId}/icon`,
+    JSON.stringify({
+      value: selectedIcon,
+    }),
+  );
+};
+
+export const getNoteInfo = async (noteId: string | null) => {
+  const instance = await getInstance();
+  const response = await instance.get(`/documents/${noteId}`);
+
+  return response.data;
+};

--- a/src/apis/note-header.ts
+++ b/src/apis/note-header.ts
@@ -10,6 +10,16 @@ export const editIcon = async (noteId: string, selectedIcon: string | null) => {
   );
 };
 
+export const editCover = async (noteId: string, selectedColor: String) => {
+  const instance = await getInstance();
+  await instance.patch(
+    `/documents/${noteId}/cover`,
+    JSON.stringify({
+      value: selectedColor,
+    }),
+  );
+};
+
 export const getNoteInfo = async (noteId: string | null) => {
   const instance = await getInstance();
   const response = await instance.get(`/documents/${noteId}`);

--- a/src/apis/note-header.ts
+++ b/src/apis/note-header.ts
@@ -44,7 +44,6 @@ export const editTags = async (noteId: string, tags: ITagType[]) => {
 export const getNoteInfo = async (noteId: string | null) => {
   const instance = await getInstance();
   const response = await instance.get(`/documents/${noteId}`);
-  console.log(response.data);
 
   return response.data;
 };

--- a/src/apis/note-header.ts
+++ b/src/apis/note-header.ts
@@ -10,12 +10,22 @@ export const editIcon = async (noteId: string, selectedIcon: string | null) => {
   );
 };
 
-export const editCover = async (noteId: string, selectedColor: String) => {
+export const editCover = async (noteId: string, selectedColor: String | null) => {
   const instance = await getInstance();
   await instance.patch(
     `/documents/${noteId}/cover`,
     JSON.stringify({
       value: selectedColor,
+    }),
+  );
+};
+
+export const editTitle = async (noteId: string, title: String | null) => {
+  const instance = await getInstance();
+  await instance.patch(
+    `/documents/${noteId}/title`,
+    JSON.stringify({
+      value: title,
     }),
   );
 };

--- a/src/apis/note-header.ts
+++ b/src/apis/note-header.ts
@@ -1,3 +1,4 @@
+import ITagType from '@/types/tag-type';
 import getInstance from '.';
 
 export const editIcon = async (noteId: string, selectedIcon: string | null) => {
@@ -30,9 +31,20 @@ export const editTitle = async (noteId: string, title: String | null) => {
   );
 };
 
+export const editTags = async (noteId: string, tags: ITagType[]) => {
+  const instance = await getInstance();
+  await instance.patch(
+    `/documents/${noteId}/tags`,
+    JSON.stringify({
+      tags,
+    }),
+  );
+};
+
 export const getNoteInfo = async (noteId: string | null) => {
   const instance = await getInstance();
   const response = await instance.get(`/documents/${noteId}`);
+  console.log(response.data);
 
   return response.data;
 };

--- a/src/app/(main)/_components/sidebar/finder/finder-card.tsx
+++ b/src/app/(main)/_components/sidebar/finder/finder-card.tsx
@@ -61,7 +61,7 @@ const emptyPageContainer = css({
 const FinderCard = () => {
   const [isHover, setIsHover] = useState(false);
 
-  const { data } = useSWR(`pageList`);
+  const { data: pageList } = useSWR('pageList');
 
   const handleClick = async () => {
     try {
@@ -84,8 +84,8 @@ const FinderCard = () => {
           </div>
         )}
       </div>
-      {data?.node.length ? (
-        data.node.map((page: IDocuments) => <PageItem key={page.id} page={page} depth={1} />)
+      {pageList?.node.length ? (
+        pageList.node.map((page: IDocuments) => <PageItem key={page.id} page={page} depth={1} />)
       ) : (
         <p className={emptyPageContainer}>문서가 없습니다.</p>
       )}

--- a/src/app/(main)/_components/sidebar/finder/page-item.tsx
+++ b/src/app/(main)/_components/sidebar/finder/page-item.tsx
@@ -14,6 +14,7 @@ import { createPage, deletePage, getPageList } from '@/apis/side-bar';
 import { mutate } from 'swr';
 import TrashIcon from '@/icons/trash-icon';
 import PencilSquareIcon from '@/icons/pencil-square';
+import { editTitle, getNoteInfo } from '@/apis/note-header';
 import DropDown from '../../../../../components/dropdown/dropdown';
 
 const pageItemContainer = css({
@@ -140,6 +141,12 @@ const PageItem = ({ page, depth }: { page: IDocuments; depth: number }) => {
     }
   };
 
+  const handleTest = async () => {
+    await editTitle(page.id, 'aa');
+    await mutate('pageList', getPageList, false);
+    await mutate('noteHeaderData', getNoteInfo(page.id), false);
+  };
+
   return (
     <div className={pageItemContainer}>
       <div
@@ -169,7 +176,7 @@ const PageItem = ({ page, depth }: { page: IDocuments; depth: number }) => {
         )}
         <DropDown handleClose={closeSettingDropdown}>
           <DropDown.Menu isOpen={isDropdownOpen} top="1rem" left="-3.7rem">
-            <DropDown.Item>
+            <DropDown.Item onClick={handleTest}>
               <PencilSquareIcon />
               제목 수정하기
             </DropDown.Item>

--- a/src/app/(main)/_components/sidebar/finder/page-item.tsx
+++ b/src/app/(main)/_components/sidebar/finder/page-item.tsx
@@ -156,7 +156,7 @@ const PageItem = ({ page, depth }: { page: IDocuments; depth: number }) => {
           {isOpen ? <PageOpenIcon color="black" /> : <PageCloseIcon color="black" />}
         </button>
         <div className={pageIcon}>{page.icon ? `${page.icon}` : <PageIcon />}</div>
-        <div className={pageTitle}>{page.title === null ? '새 페이지' : page.title}</div>
+        <div className={pageTitle}>{page.title === null || page.title === '' ? '새 페이지' : page.title}</div>
         {isHover && (
           <div className={pageButtonContainer}>
             <button type="button" ref={settingButtonRef} className={pageButton} onClick={openSettingDropdown}>

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -15,20 +15,22 @@ const RootLayout = async ({ children, modal }: Readonly<{ children: React.ReactN
     redirect('/login');
   }
 
-  const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/documents`, {
+  const pageResponse = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/documents`, {
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
     },
   });
 
-  const pageList = response.data;
+  const noteHeaderData = null;
+  const pageList = pageResponse.data;
 
   return (
     <SWRConfig
       value={{
         fallback: {
           [`pageList`]: pageList,
+          [`noteHeaderData`]: noteHeaderData,
         },
       }}
     >

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -22,13 +22,13 @@ const RootLayout = async ({ children, modal }: Readonly<{ children: React.ReactN
     },
   });
 
-  const sidebarData = response.data;
+  const pageList = response.data;
 
   return (
     <SWRConfig
       value={{
         fallback: {
-          [`pageList`]: sidebarData,
+          [`pageList`]: pageList,
         },
       }}
     >

--- a/src/app/(main)/note/[id]/_components/note-header/note-header.tsx
+++ b/src/app/(main)/note/[id]/_components/note-header/note-header.tsx
@@ -156,7 +156,7 @@ const NoteHeader = () => {
           handleSelectIcon={handleSelectIcon}
           handleSelectCover={handleSelectCover}
         />
-        <Title title={data.title} noteId={noteId} />
+        <Title noteId={noteId} />
       </div>
       <Tag noteId={noteId} />
     </>

--- a/src/app/(main)/note/[id]/_components/note-header/note-header.tsx
+++ b/src/app/(main)/note/[id]/_components/note-header/note-header.tsx
@@ -149,7 +149,7 @@ const NoteHeader = () => {
         />
         <Title noteId={noteId} />
       </div>
-      <Tag />
+      <Tag noteId={noteId} />
     </>
   );
 };

--- a/src/app/(main)/note/[id]/_components/note-header/note-header.tsx
+++ b/src/app/(main)/note/[id]/_components/note-header/note-header.tsx
@@ -96,8 +96,9 @@ const NoteHeader = () => {
     await mutate('noteHeaderData', getNoteInfo(noteId), false);
   };
 
-  const deleteCover = () => {
-    setCover(null);
+  const deleteCover = async () => {
+    await editCover(noteId, null);
+    await mutate('noteHeaderData', getNoteInfo(noteId), false);
   };
 
   const iconSelectorRef = useClickOutside(handleSelectorClose);
@@ -146,7 +147,7 @@ const NoteHeader = () => {
           handleSelectIcon={handleSelectIcon}
           handleSelectCover={handleSelectCover}
         />
-        <Title />
+        <Title noteId={noteId} />
       </div>
       <Tag />
     </>

--- a/src/app/(main)/note/[id]/_components/note-header/note-header.tsx
+++ b/src/app/(main)/note/[id]/_components/note-header/note-header.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { css } from '@/../styled-system/css';
 import useClickOutside from '@/hooks/useClickOutside';
 import useSWR, { mutate } from 'swr';
 import { useParams } from 'next/navigation';
 import { editCover, editIcon, getNoteInfo } from '@/apis/note-header';
+import { getPageList } from '@/apis/side-bar';
 import IconSelector from './icon-selector';
 import Tag from './tag';
 import Title from './title';
@@ -60,7 +61,11 @@ const NoteHeader = () => {
   const params = useParams();
   const noteId = params.id as string;
 
-  const { data } = useSWR(`noteHeaderData`);
+  const { data } = useSWR('noteHeaderData');
+
+  useEffect(() => {
+    mutate('noteHeaderData', getNoteInfo(noteId));
+  }, []);
 
   const handleMouseEnter = () => {
     setIsHover(true);
@@ -72,7 +77,8 @@ const NoteHeader = () => {
 
   const handleSelectIcon = async (selectedIcon: string | null) => {
     await editIcon(noteId, selectedIcon);
-    await mutate('noteHeaderData', getNoteInfo(noteId), false);
+    await mutate('pageList', getPageList, false);
+    await mutate('noteHeaderData', getNoteInfo(noteId));
   };
 
   const handleSelectorOpen = () => {
@@ -93,15 +99,18 @@ const NoteHeader = () => {
 
   const handleSelectCover = async (selectedColor: string) => {
     await editCover(noteId, selectedColor);
+    await mutate('pageList', getPageList, false);
     await mutate('noteHeaderData', getNoteInfo(noteId), false);
   };
 
   const deleteCover = async () => {
     await editCover(noteId, null);
+    await mutate('pageList', getPageList, false);
     await mutate('noteHeaderData', getNoteInfo(noteId), false);
   };
 
   const iconSelectorRef = useClickOutside(handleSelectorClose);
+  if (!data) return null;
 
   return (
     <>
@@ -147,7 +156,7 @@ const NoteHeader = () => {
           handleSelectIcon={handleSelectIcon}
           handleSelectCover={handleSelectCover}
         />
-        <Title noteId={noteId} />
+        <Title title={data.title} noteId={noteId} />
       </div>
       <Tag noteId={noteId} />
     </>

--- a/src/app/(main)/note/[id]/_components/note-header/note-header.tsx
+++ b/src/app/(main)/note/[id]/_components/note-header/note-header.tsx
@@ -5,7 +5,7 @@ import { css } from '@/../styled-system/css';
 import useClickOutside from '@/hooks/useClickOutside';
 import useSWR, { mutate } from 'swr';
 import { useParams } from 'next/navigation';
-import { editIcon, getNoteInfo } from '@/apis/note-header';
+import { editCover, editIcon, getNoteInfo } from '@/apis/note-header';
 import IconSelector from './icon-selector';
 import Tag from './tag';
 import Title from './title';
@@ -91,8 +91,9 @@ const NoteHeader = () => {
     setIsCoverModalOpen(false);
   };
 
-  const handleSelectCover = (selectedColor: string) => {
-    setCover(selectedColor);
+  const handleSelectCover = async (selectedColor: string) => {
+    await editCover(noteId, selectedColor);
+    await mutate('noteHeaderData', getNoteInfo(noteId), false);
   };
 
   const deleteCover = () => {

--- a/src/app/(main)/note/[id]/_components/note-header/tag-box.tsx
+++ b/src/app/(main)/note/[id]/_components/note-header/tag-box.tsx
@@ -25,12 +25,12 @@ const tagBox = cva({
   },
   variants: {
     color: {
-      lineOne: { backgroundColor: 'lineOne' },
-      lineTwo: { backgroundColor: 'lineTwo' },
-      lineThree: { backgroundColor: 'lineThree' },
-      lineFour: { backgroundColor: 'lineFour' },
-      lineFive: { backgroundColor: 'lineFive' },
-      lineSix: { backgroundColor: 'lineSix' },
+      LINE_ONE: { backgroundColor: 'lineOne' },
+      LINE_TWO: { backgroundColor: 'lineTwo' },
+      LINE_THREE: { backgroundColor: 'lineThree' },
+      LINE_FOUR: { backgroundColor: 'lineFour' },
+      LINE_FIVE: { backgroundColor: 'lineFive' },
+      LINE_SIX: { backgroundColor: 'lineSix' },
     },
   },
 });

--- a/src/app/(main)/note/[id]/_components/note-header/tag.tsx
+++ b/src/app/(main)/note/[id]/_components/note-header/tag.tsx
@@ -7,6 +7,7 @@ import keyName from '@/constants/key-name';
 import useClickOutside from '@/hooks/useClickOutside';
 import useSWR, { mutate } from 'swr';
 import { editTags, getNoteInfo } from '@/apis/note-header';
+import { getPageList } from '@/apis/side-bar';
 import TagBox from './tag-box';
 
 interface ITag {
@@ -115,6 +116,7 @@ const Tag = ({ noteId }: ITag) => {
       }
 
       await editTags(noteId, [...tagList, { name: inputValue.trim(), color: getRandomColor() }]);
+      await mutate('pageList', getPageList, false);
       await mutate('noteHeaderData', getNoteInfo(noteId), false);
 
       setIsEditing(false);
@@ -126,6 +128,7 @@ const Tag = ({ noteId }: ITag) => {
       noteId,
       tagList.filter(tag => tag.name !== tagToDelete),
     );
+    await mutate('pageList', getPageList, false);
     await mutate('noteHeaderData', getNoteInfo(noteId), false);
   };
 

--- a/src/app/(main)/note/[id]/_components/note-header/tag.tsx
+++ b/src/app/(main)/note/[id]/_components/note-header/tag.tsx
@@ -5,7 +5,13 @@ import ITagType from '@/types/tag-type';
 import LineColor from '@/constants/line-color';
 import keyName from '@/constants/key-name';
 import useClickOutside from '@/hooks/useClickOutside';
+import useSWR, { mutate } from 'swr';
+import { editTags, getNoteInfo } from '@/apis/note-header';
 import TagBox from './tag-box';
+
+interface ITag {
+  noteId: string;
+}
 
 const tagContainer = css({
   minHeight: '2rem',
@@ -63,8 +69,10 @@ const tagInput = css({
   color: 'black',
 });
 
-const Tag = () => {
-  const [tagList, setTagList] = useState<ITagType[]>([]);
+const Tag = ({ noteId }: ITag) => {
+  const { data = { tags: [] } } = useSWR<{ tags: ITagType[] }>('noteHeaderData');
+  const tagList = data.tags;
+
   const [isEditing, setIsEditing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -90,7 +98,7 @@ const Tag = () => {
     }
   }, [isEditing]);
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
     const inputValue = e.currentTarget.value;
     const isDuplicate = tagList.some(tag => tag.name === inputValue);
 
@@ -98,6 +106,7 @@ const Tag = () => {
       if (e.nativeEvent.isComposing) {
         return;
       }
+
       if (isDuplicate || inputValue.trim() === '') {
         inputRef.current?.blur();
         e.currentTarget.value = '';
@@ -105,14 +114,19 @@ const Tag = () => {
         return;
       }
 
-      setTagList([...tagList, { name: inputValue.trim(), color: getRandomColor() }]);
-      e.currentTarget.value = '';
+      await editTags(noteId, [...tagList, { name: inputValue.trim(), color: getRandomColor() }]);
+      await mutate('noteHeaderData', getNoteInfo(noteId), false);
+
       setIsEditing(false);
     }
   };
 
-  const handleTagDelete = (tagToDelete: string) => {
-    setTagList(tagList.filter(tag => tag.name !== tagToDelete));
+  const handleTagDelete = async (tagToDelete: string) => {
+    await editTags(
+      noteId,
+      tagList.filter(tag => tag.name !== tagToDelete),
+    );
+    await mutate('noteHeaderData', getNoteInfo(noteId), false);
   };
 
   return (

--- a/src/app/(main)/note/[id]/_components/note-header/title.tsx
+++ b/src/app/(main)/note/[id]/_components/note-header/title.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { css } from '@/../styled-system/css';
-import useSWR, { mutate } from 'swr';
+import { mutate } from 'swr';
 import { editTitle, getNoteInfo } from '@/apis/note-header';
 import { getPageList } from '@/apis/side-bar';
 

--- a/src/app/(main)/note/[id]/_components/note-header/title.tsx
+++ b/src/app/(main)/note/[id]/_components/note-header/title.tsx
@@ -1,10 +1,12 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { css } from '@/../styled-system/css';
-import useSWR, { mutate } from 'swr';
+import { mutate } from 'swr';
 import { editTitle, getNoteInfo } from '@/apis/note-header';
+import { getPageList } from '@/apis/side-bar';
 
 interface ITitle {
   noteId: string;
+  title: string;
 }
 
 const titleFont = css({
@@ -26,21 +28,25 @@ const titleFont = css({
   },
 });
 
-const Title = ({ noteId }: ITitle) => {
-  const { data } = useSWR(`noteHeaderData`);
-
-  const [value, setValue] = useState(data.title);
+const Title = ({ noteId, title }: ITitle) => {
+  const [value, setValue] = useState(title);
 
   const isHovered = useRef(false);
   const [isScrollable, setIsScrollable] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  const updateTitle = async (titleValue: string) => {
+    await editTitle(noteId, titleValue);
+    await mutate('pageList', getPageList, false);
+    await mutate('noteHeaderData', getNoteInfo(noteId), false);
+  };
+
+  useEffect(() => {
+    updateTitle(value);
+  }, [value]);
+
   const handleChange = async (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setValue(e.target.value);
-
-    await editTitle(noteId, e.target.value);
-    await mutate('noteHeaderData', getNoteInfo(noteId), false);
-
     const textarea = textareaRef.current;
 
     if (textarea) {

--- a/src/app/(main)/note/[id]/_components/note-header/title.tsx
+++ b/src/app/(main)/note/[id]/_components/note-header/title.tsx
@@ -1,5 +1,11 @@
 import { useState, useRef } from 'react';
 import { css } from '@/../styled-system/css';
+import useSWR, { mutate } from 'swr';
+import { editTitle, getNoteInfo } from '@/apis/note-header';
+
+interface ITitle {
+  noteId: string;
+}
 
 const titleFont = css({
   fontSize: 'lg',
@@ -20,14 +26,21 @@ const titleFont = css({
   },
 });
 
-const Title = () => {
-  const [value, setValue] = useState('');
+const Title = ({ noteId }: ITitle) => {
+  const { data } = useSWR(`noteHeaderData`);
+
+  const [value, setValue] = useState(data.title);
+
   const isHovered = useRef(false);
   const [isScrollable, setIsScrollable] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+  const handleChange = async (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setValue(e.target.value);
+
+    await editTitle(noteId, e.target.value);
+    await mutate('noteHeaderData', getNoteInfo(noteId), false);
+
     const textarea = textareaRef.current;
 
     if (textarea) {

--- a/src/app/(main)/note/[id]/_components/note-header/title.tsx
+++ b/src/app/(main)/note/[id]/_components/note-header/title.tsx
@@ -85,7 +85,7 @@ const Title = ({ noteId }: ITitle) => {
       className={titleFont}
       placeholder="새 페이지"
       rows={1}
-      value={value}
+      value={value === null ? '' : value}
       onChange={handleChange}
       onMouseLeave={handleMouseLeave}
       onMouseEnter={handleMouseEnter}

--- a/src/app/(main)/note/[id]/_components/note-header/title.tsx
+++ b/src/app/(main)/note/[id]/_components/note-header/title.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { css } from '@/../styled-system/css';
-import { mutate } from 'swr';
+import useSWR, { mutate } from 'swr';
 import { editTitle, getNoteInfo } from '@/apis/note-header';
 import { getPageList } from '@/apis/side-bar';
 
@@ -28,29 +28,42 @@ const titleFont = css({
 });
 
 const Title = ({ noteId }: ITitle) => {
-  const [value, setValue] = useState('');
+  const { data } = useSWR('noteHeaderData');
+
+  const [value, setValue] = useState(data.title);
   const isHovered = useRef(false);
   const [isScrollable, setIsScrollable] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const debounceTimer = useRef<NodeJS.Timeout | null>(null);
 
   const getNewTitle = async () => {
     const newTitle = await mutate('noteHeaderData', getNoteInfo(noteId), false);
     setValue(newTitle.title);
   };
 
-  const updateTitle = async (titleValue: string) => {
-    await editTitle(noteId, titleValue);
-    await mutate('pageList', getPageList, false);
-    await mutate('noteHeaderData', getNoteInfo(noteId), false);
-  };
+  useEffect(() => {
+    if (debounceTimer.current) clearTimeout(debounceTimer.current);
+
+    debounceTimer.current = setTimeout(async () => {
+      await editTitle(noteId, value);
+      await mutate('pageList', getPageList, false);
+    }, 100);
+
+    return () => {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    };
+  }, [value, noteId]);
 
   useEffect(() => {
     getNewTitle();
   }, []);
 
+  useEffect(() => {
+    setValue(data.title);
+  }, [data]);
+
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setValue(e.target.value);
-    updateTitle(e.target.value);
     const textarea = textareaRef.current;
     if (textarea) {
       textarea.style.height = 'auto';

--- a/src/app/(main)/note/[id]/page.tsx
+++ b/src/app/(main)/note/[id]/page.tsx
@@ -46,11 +46,12 @@ const divider = css({
   borderRadius: '1rem',
 });
 
-const Note = async ({ params }: { params: { id: string } }) => {
+const Note = async ({ params }: { params: Promise<{ id: string }> }) => {
   const cookie = await cookies();
   const accessToken = cookie?.get('accessToken')?.value;
+  const { id } = await params;
 
-  const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/documents/${params.id}`, {
+  const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/documents/${id}`, {
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,

--- a/src/app/(main)/note/[id]/page.tsx
+++ b/src/app/(main)/note/[id]/page.tsx
@@ -1,5 +1,8 @@
 import { css } from '@/../styled-system/css';
 
+import axios from 'axios';
+import { cookies } from 'next/headers';
+import { SWRConfig } from 'swr';
 import Header from './_components/header';
 import NoteHeader from './_components/note-header/note-header';
 import LineInfo from './_components/line-info/line-info';
@@ -43,20 +46,41 @@ const divider = css({
   borderRadius: '1rem',
 });
 
-const Note = async () => {
+const Note = async ({ params }: { params: Promise<{ id: string }> }) => {
+  const cookie = await cookies();
+  const accessToken = cookie?.get('accessToken')?.value;
+  const { id } = await params;
+
+  const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/documents/${id}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  const noteHedaerData = response.data;
+
   return (
-    <div className={container}>
-      <Header />
-      <div className={contentContainer}>
-        <div className={noteContainer}>
-          <NoteHeader />
-          <div className={divider} />
-          <LineInfo />
-          <div className={divider} />
-          <NoteConent />
+    <SWRConfig
+      value={{
+        fallback: {
+          [`noteHedaerData`]: noteHedaerData,
+        },
+      }}
+    >
+      <div className={container}>
+        <Header />
+        <div className={contentContainer}>
+          <div className={noteContainer}>
+            <NoteHeader />
+            <div className={divider} />
+            <LineInfo />
+            <div className={divider} />
+            <NoteConent />
+          </div>
         </div>
       </div>
-    </div>
+    </SWRConfig>
   );
 };
 

--- a/src/app/(main)/note/[id]/page.tsx
+++ b/src/app/(main)/note/[id]/page.tsx
@@ -1,8 +1,5 @@
 import { css } from '@/../styled-system/css';
 
-import axios from 'axios';
-import { cookies } from 'next/headers';
-import { SWRConfig } from 'swr';
 import Header from './_components/header';
 import NoteHeader from './_components/note-header/note-header';
 import LineInfo from './_components/line-info/line-info';
@@ -46,41 +43,20 @@ const divider = css({
   borderRadius: '1rem',
 });
 
-const Note = async ({ params }: { params: Promise<{ id: string }> }) => {
-  const cookie = await cookies();
-  const accessToken = cookie?.get('accessToken')?.value;
-  const { id } = await params;
-
-  const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/documents/${id}`, {
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
-
-  const noteHeaderData = response.data;
-
+const Note = async () => {
   return (
-    <SWRConfig
-      value={{
-        fallback: {
-          [`noteHeaderData`]: noteHeaderData,
-        },
-      }}
-    >
-      <div className={container}>
-        <Header />
-        <div className={contentContainer}>
-          <div className={noteContainer}>
-            <NoteHeader />
-            <div className={divider} />
-            <LineInfo />
-            <div className={divider} />
-            <NoteConent />
-          </div>
+    <div className={container}>
+      <Header />
+      <div className={contentContainer}>
+        <div className={noteContainer}>
+          <NoteHeader />
+          <div className={divider} />
+          <LineInfo />
+          <div className={divider} />
+          <NoteConent />
         </div>
       </div>
-    </SWRConfig>
+    </div>
   );
 };
 

--- a/src/app/(main)/note/[id]/page.tsx
+++ b/src/app/(main)/note/[id]/page.tsx
@@ -1,5 +1,8 @@
 import { css } from '@/../styled-system/css';
 
+import axios from 'axios';
+import { cookies } from 'next/headers';
+import { SWRConfig } from 'swr';
 import Header from './_components/header';
 import NoteHeader from './_components/note-header/note-header';
 import LineInfo from './_components/line-info/line-info';
@@ -43,20 +46,40 @@ const divider = css({
   borderRadius: '1rem',
 });
 
-const Note = () => {
+const Note = async ({ params }: { params: { id: string } }) => {
+  const cookie = await cookies();
+  const accessToken = cookie?.get('accessToken')?.value;
+
+  const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/documents/${params.id}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  const noteHeaderData = response.data;
+
   return (
-    <div className={container}>
-      <Header />
-      <div className={contentContainer}>
-        <div className={noteContainer}>
-          <NoteHeader />
-          <div className={divider} />
-          <LineInfo />
-          <div className={divider} />
-          <NoteConent />
+    <SWRConfig
+      value={{
+        fallback: {
+          [`noteHeaderData`]: noteHeaderData,
+        },
+      }}
+    >
+      <div className={container}>
+        <Header />
+        <div className={contentContainer}>
+          <div className={noteContainer}>
+            <NoteHeader />
+            <div className={divider} />
+            <LineInfo />
+            <div className={divider} />
+            <NoteConent />
+          </div>
         </div>
       </div>
-    </div>
+    </SWRConfig>
   );
 };
 

--- a/src/constants/line-color.ts
+++ b/src/constants/line-color.ts
@@ -1,10 +1,10 @@
 const LineColor = {
-  lineOne: 'lineOne',
-  lineTwo: 'lineTwo',
-  lineThree: 'lineThree',
-  lineFour: 'lineFour',
-  lineFive: 'lineFive',
-  lineSix: 'lineSix',
+  LINE_ONE: 'LINE_ONE',
+  LINE_TWO: 'LINE_TWO',
+  LINE_THREE: 'LINE_TWO',
+  LINE_FOUR: 'LINE_TWO',
+  LINE_FIVE: 'LINE_TWO',
+  LINE_SIX: 'LINE_TWO',
 };
 
 export default LineColor;


### PR DESCRIPTION
## 📝 PR Description

- note header api 연동

---

## 🔍 Changes Made

- note header 부분 api 구현
  - cover api 연동
  - icon api 연동
  - tags api 연동
  - title api 연동
- 사이드바와도 연결
---

## 🔄 Extra Comments

- 사이드바에도 note header의 변경값이 반영되어야 하기에 main Layout에서 fallback을 통해 내려주도록 수정하였습니다.
- 그 과정에서 noteId를 main Layout에서 받아올 수 없기에 null값으로 내려준 뒤, mutate로 갱신을 해주는 방법을 선택하였습니다.

---

## 📷 Demo

https://github.com/user-attachments/assets/b522cc53-688d-4d63-8d2c-7c86f2474f44

Uploading Metro - Chrome 2025-02-25 18-25-01.mp4…

---
