### PR TITLE
feat: title 블록 구현

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -6,7 +6,7 @@ import { SWRConfig } from 'swr';
 import axios from 'axios';
 import Sidebar from './_components/sidebar/sidebar';
 
-const RootLayout = async ({ children, modal }: Readonly<{ children: React.ReactNode; modal: React.ReactNode }>) => {
+const MainLayout = async ({ children, modal }: Readonly<{ children: React.ReactNode; modal: React.ReactNode }>) => {
   const cookie = await cookies();
   const isLogin = cookie.has('accessToken');
   const accessToken = cookie?.get('accessToken')?.value;
@@ -41,4 +41,4 @@ const RootLayout = async ({ children, modal }: Readonly<{ children: React.ReactN
   );
 };
 
-export default RootLayout;
+export default MainLayout;

--- a/src/app/(main)/note/[id]/_components/note-content/block-button.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block-button.tsx
@@ -6,6 +6,8 @@ import GripVerticalIcon from '@/icons/grip-vertical-icon';
 const blockBtnContainer = css({
   position: 'absolute',
   left: '2rem',
+  top: '50%',
+  transform: 'translateY(-50%)',
   display: 'flex',
   flexDirection: 'row',
 });

--- a/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleInput.ts
+++ b/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleInput.ts
@@ -33,9 +33,6 @@ const handleInput = (
       type: 'text',
       content: '',
     };
-
-    // setBlockList(updatedBlockList);
-    // return;
   }
 
   // block의 자식 노드가 지워졌을 때 blockList에 반영하는 로직

--- a/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleInput.ts
+++ b/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleInput.ts
@@ -6,14 +6,15 @@ const handleInput = (
   index: number,
   blockList: ITextBlock[],
   setBlockList: (blockList: ITextBlock[]) => void,
-  blockRef: React.RefObject<(HTMLDivElement | null)[]>,
   prevChildNodesLength: React.RefObject<number>,
 ) => {
   const updatedBlockList = [...blockList];
-  const target = event.currentTarget;
+  const target = event.currentTarget.childNodes[0] as HTMLElement;
+
+  target.setAttribute('data-empty', 'false');
 
   const { startOffset, startContainer } = getSelectionInfo(0) || {};
-  if (!startOffset || !startContainer) return;
+  if (startOffset === undefined || startOffset === null || !startContainer) return;
 
   const childNodes = Array.from(target.childNodes as NodeListOf<HTMLElement>);
   const currentChildNodeIndex =
@@ -21,11 +22,8 @@ const handleInput = (
       ? childNodes.indexOf(startContainer.parentNode as HTMLElement)
       : childNodes.indexOf(startContainer as HTMLElement);
 
-  // 블록에 모든 내용이 지워졌을 때 빈 블록으로 변경 로직
-  if (currentChildNodeIndex === -1 && blockRef.current[index] && childNodes.length === 1) {
-    // eslint-disable-next-line no-param-reassign
-    blockRef.current[index]!.innerHTML = '';
-    return;
+  if (childNodes.length === 1 && target.textContent === '') {
+    target.setAttribute('data-empty', 'true');
   }
 
   // block의 자식 노드가 지워졌을 때 blockList에 반영하는 로직
@@ -57,6 +55,9 @@ const handleInput = (
   const updatedChildList = updatedBlockList[index].children
     .map((child, idx) => {
       if (child.type === 'text' && child.content === '') {
+        if (updatedBlockList[index].children.length === 1) {
+          return child;
+        }
         if (idx === updatedBlockList[index].children.length - 1) {
           return {
             type: 'br' as 'br',

--- a/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleInput.ts
+++ b/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleInput.ts
@@ -6,6 +6,7 @@ const handleInput = (
   index: number,
   blockList: ITextBlock[],
   setBlockList: (blockList: ITextBlock[]) => void,
+  blockRef: React.RefObject<(HTMLDivElement | null)[]>,
   prevChildNodesLength: React.RefObject<number>,
 ) => {
   const updatedBlockList = [...blockList];
@@ -24,6 +25,17 @@ const handleInput = (
 
   if (childNodes.length === 1 && target.textContent === '') {
     target.setAttribute('data-empty', 'true');
+  }
+
+  // 블록에 모든 내용이 지워졌을 때 빈 블록으로 변경 로직
+  if (currentChildNodeIndex === -1 && blockRef.current[index] && childNodes.length === 1) {
+    updatedBlockList[index].children[0] = {
+      type: 'text',
+      content: '',
+    };
+
+    // setBlockList(updatedBlockList);
+    // return;
   }
 
   // block의 자식 노드가 지워졌을 때 blockList에 반영하는 로직
@@ -52,24 +64,26 @@ const handleInput = (
     currentChildNodeIndex !== -1 ? childNodes[currentChildNodeIndex].textContent || '' : '';
 
   // 블록 중간에 빈 textNode가 생기면 삭제하고, 마지막 줄에 빈 textNode 생기면 <br>로 변경
-  const updatedChildList = updatedBlockList[index].children
-    .map((child, idx) => {
-      if (child.type === 'text' && child.content === '') {
-        if (updatedBlockList[index].children.length === 1) {
-          return child;
+  if (currentChildNodeIndex === -1) {
+    const updatedChildList = updatedBlockList[index].children
+      .map((child, idx) => {
+        if (child.type === 'text' && child.content === '') {
+          if (updatedBlockList[index].children.length === 1) {
+            return child;
+          }
+          if (idx === updatedBlockList[index].children.length - 1) {
+            return {
+              type: 'br' as 'br',
+            };
+          }
+          return '';
         }
-        if (idx === updatedBlockList[index].children.length - 1) {
-          return {
-            type: 'br' as 'br',
-          };
-        }
-        return '';
-      }
-      return child;
-    })
-    .filter(child => child !== '');
+        return child;
+      })
+      .filter(child => child !== '');
 
-  updatedBlockList[index].children = updatedChildList;
+    updatedBlockList[index].children = updatedChildList;
+  }
 
   setBlockList(updatedBlockList);
   // eslint-disable-next-line no-param-reassign

--- a/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleKeyDown.ts
+++ b/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleKeyDown.ts
@@ -304,6 +304,14 @@ const turnIntoH2 = (index: number, blockList: ITextBlock[], setBlockList: (block
   setBlockList(updatedBlockList);
 };
 
+const turnIntoH3 = (index: number, blockList: ITextBlock[], setBlockList: (blockList: ITextBlock[]) => void) => {
+  const updatedBlockList = [...blockList];
+  updatedBlockList[index].type = 'h3';
+  updatedBlockList[index].children[0].content = (updatedBlockList[index].children[0].content as string).substring(3);
+
+  setBlockList(updatedBlockList);
+};
+
 const handleKeyDown = (
   event: React.KeyboardEvent<HTMLDivElement>,
   index: number,
@@ -425,6 +433,22 @@ const handleKeyDown = (
       setIsTyping(false);
       setKey(Math.random());
       turnIntoH2(index, blockList, setBlockList);
+    }
+
+    // h3으로 전환
+    if (
+      currentChildNodeIndex === 0 &&
+      startOffset === 3 &&
+      startContainer.textContent &&
+      startContainer.textContent[0] === '#' &&
+      startContainer.textContent[1] === '#' &&
+      startContainer.textContent[2] === '#' &&
+      blockList[index].type !== 'h3'
+    ) {
+      event.preventDefault();
+      setIsTyping(false);
+      setKey(Math.random());
+      turnIntoH3(index, blockList, setBlockList);
     }
   }
 };

--- a/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleKeyDown.ts
+++ b/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleKeyDown.ts
@@ -296,6 +296,14 @@ const turnIntoH1 = (index: number, blockList: ITextBlock[], setBlockList: (block
   setBlockList(updatedBlockList);
 };
 
+const turnIntoH2 = (index: number, blockList: ITextBlock[], setBlockList: (blockList: ITextBlock[]) => void) => {
+  const updatedBlockList = [...blockList];
+  updatedBlockList[index].type = 'h2';
+  updatedBlockList[index].children[0].content = (updatedBlockList[index].children[0].content as string).substring(2);
+
+  setBlockList(updatedBlockList);
+};
+
 const handleKeyDown = (
   event: React.KeyboardEvent<HTMLDivElement>,
   index: number,
@@ -390,16 +398,33 @@ const handleKeyDown = (
         ? childNodes.indexOf(startContainer.parentNode as HTMLElement)
         : childNodes.indexOf(startContainer as HTMLElement);
 
+    // h1으로 전환
     if (
       currentChildNodeIndex === 0 &&
       startOffset === 1 &&
       startContainer.textContent &&
-      startContainer.textContent[0] === '#'
+      startContainer.textContent[0] === '#' &&
+      blockList[index].type !== 'h1'
     ) {
       event.preventDefault();
       setIsTyping(false);
       setKey(Math.random());
       turnIntoH1(index, blockList, setBlockList);
+    }
+
+    // h2로 전환
+    if (
+      currentChildNodeIndex === 0 &&
+      startOffset === 2 &&
+      startContainer.textContent &&
+      startContainer.textContent[0] === '#' &&
+      startContainer.textContent[1] === '#' &&
+      blockList[index].type !== 'h2'
+    ) {
+      event.preventDefault();
+      setIsTyping(false);
+      setKey(Math.random());
+      turnIntoH2(index, blockList, setBlockList);
     }
   }
 };

--- a/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleKeyDown.ts
+++ b/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleKeyDown.ts
@@ -288,6 +288,14 @@ const mergeLine = (
   setBlockList(updatedBlockList);
 };
 
+const turnIntoH1 = (index: number, blockList: ITextBlock[], setBlockList: (blockList: ITextBlock[]) => void) => {
+  const updatedBlockList = [...blockList];
+  updatedBlockList[index].type = 'h1';
+  updatedBlockList[index].children[0].content = (updatedBlockList[index].children[0].content as string).substring(1);
+
+  setBlockList(updatedBlockList);
+};
+
 const handleKeyDown = (
   event: React.KeyboardEvent<HTMLDivElement>,
   index: number,
@@ -368,6 +376,30 @@ const handleKeyDown = (
       } else if (currentChildNodeIndex > 0) {
         mergeLine(index, currentChildNodeIndex, blockList, setBlockList);
       }
+    }
+  }
+
+  if (event.key === keyName.space) {
+    const { startOffset, startContainer } = getSelectionInfo(0) || {};
+    if (startOffset === undefined || startOffset === null || !startContainer) return;
+
+    const parent = blockRef.current[index];
+    const childNodes = Array.from(parent?.childNodes as NodeListOf<HTMLElement>);
+    const currentChildNodeIndex =
+      childNodes.indexOf(startContainer as HTMLElement) === -1 && startContainer?.nodeType === Node.TEXT_NODE
+        ? childNodes.indexOf(startContainer.parentNode as HTMLElement)
+        : childNodes.indexOf(startContainer as HTMLElement);
+
+    if (
+      currentChildNodeIndex === 0 &&
+      startOffset === 1 &&
+      startContainer.textContent &&
+      startContainer.textContent[0] === '#'
+    ) {
+      event.preventDefault();
+      setIsTyping(false);
+      setKey(Math.random());
+      turnIntoH1(index, blockList, setBlockList);
     }
   }
 };

--- a/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleKeyDown.ts
+++ b/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleKeyDown.ts
@@ -477,14 +477,3 @@ const handleKeyDown = (
 };
 
 export default handleKeyDown;
-
-// server: fetch -> fallback
-// client: fetch: (fallback, fetcher)
-
-// null은 아닌건 같다. client사용하듯이 똑같이 해야한다
-
-// A 컴포넌트: useSWR('headerData', fetcher)
-// B 컴포넌트: useSWR('headerData', fetcher)
-// C 컴포넌트: mutation('headerData')
-// 서버에서 HTML을 그려줄 때 미리 받아와서 캐시 데이터에 넣고 싶다.
-// client에서는 fallback에 저장된 데이터를 쓰겠다.

--- a/src/app/(main)/note/[id]/_components/note-content/block/block-tag.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block/block-tag.tsx
@@ -28,6 +28,24 @@ const placeholderDiv = css({
   },
 });
 
+const placeholderH1 = css({
+  position: 'relative',
+
+  '.parent:focus-within &': {
+    '&[data-empty=true]': {
+      '&::before': {
+        position: 'absolute',
+        top: '0',
+        left: '5rem',
+        content: 'attr(data-placeholder)',
+        color: 'gray',
+        fontSize: 'lg',
+        pointerEvents: 'none',
+      },
+    },
+  },
+});
+
 const BlockTag = ({ block, index, blockRef, children }: IBlockTag) => {
   if (block.type === 'default') {
     return (
@@ -42,6 +60,22 @@ const BlockTag = ({ block, index, blockRef, children }: IBlockTag) => {
       >
         {children}
       </p>
+    );
+  }
+
+  if (block.type === 'h1') {
+    return (
+      <h1
+        data-placeholder={placeholder.h1}
+        data-empty={`${block.children.length === 1 && block.children[0].content === ''}`}
+        className={placeholderH1}
+        ref={element => {
+          // eslint-disable-next-line no-param-reassign
+          blockRef.current[index] = element;
+        }}
+      >
+        {children}
+      </h1>
     );
   }
 

--- a/src/app/(main)/note/[id]/_components/note-content/block/block-tag.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block/block-tag.tsx
@@ -1,0 +1,51 @@
+import { css } from '@/../styled-system/css';
+
+import { ITextBlock } from '@/types/block-type';
+import placeholder from '@/constants/placeholder';
+
+interface IBlockTag {
+  block: ITextBlock;
+  index: number;
+  blockRef: React.RefObject<(HTMLDivElement | null)[]>;
+  children: React.ReactNode[];
+}
+
+const placeholderDiv = css({
+  position: 'relative',
+
+  '.parent:focus-within &': {
+    '&[data-empty=true]': {
+      '&::before': {
+        position: 'absolute',
+        top: '0',
+        left: '0',
+        content: 'attr(data-placeholder)',
+        color: 'gray',
+        fontSize: 'md',
+        pointerEvents: 'none',
+      },
+    },
+  },
+});
+
+const BlockTag = ({ block, index, blockRef, children }: IBlockTag) => {
+  if (block.type === 'default') {
+    return (
+      <p
+        data-placeholder={placeholder.block}
+        data-empty={`${block.children.length === 1 && block.children[0].content === ''}`}
+        className={placeholderDiv}
+        ref={element => {
+          // eslint-disable-next-line no-param-reassign
+          blockRef.current[index] = element;
+        }}
+      >
+        {children}
+      </p>
+    );
+  }
+
+  return null;
+};
+
+export default BlockTag;

--- a/src/app/(main)/note/[id]/_components/note-content/block/block-tag.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block/block-tag.tsx
@@ -49,6 +49,14 @@ const placeholderStyles = cva({
           },
         },
       },
+      h3: {
+        '.parent:focus-within &': {
+          '&[data-empty=true]::before': {
+            left: '5rem',
+            fontSize: '1.25rem',
+          },
+        },
+      },
     },
   },
 });
@@ -99,6 +107,22 @@ const BlockTag = ({ block, index, blockRef, children }: IBlockTag) => {
       >
         {children}
       </h2>
+    );
+  }
+
+  if (block.type === 'h3') {
+    return (
+      <h3
+        data-placeholder={placeholder.h3}
+        data-empty={`${block.children.length === 1 && block.children[0].content === ''}`}
+        className={placeholderStyles({ tag: 'h3' })}
+        ref={element => {
+          // eslint-disable-next-line no-param-reassign
+          blockRef.current[index] = element;
+        }}
+      >
+        {children}
+      </h3>
     );
   }
 

--- a/src/app/(main)/note/[id]/_components/note-content/block/block-tag.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block/block-tag.tsx
@@ -1,4 +1,4 @@
-import { css } from '@/../styled-system/css';
+import { cva } from '@/../styled-system/css';
 
 import { ITextBlock } from '@/types/block-type';
 import placeholder from '@/constants/placeholder';
@@ -10,37 +10,44 @@ interface IBlockTag {
   children: React.ReactNode[];
 }
 
-const placeholderDiv = css({
-  position: 'relative',
-
-  '.parent:focus-within &': {
-    '&[data-empty=true]': {
-      '&::before': {
+const placeholderStyles = cva({
+  base: {
+    position: 'relative',
+    '.parent:focus-within &': {
+      '&[data-empty=true]::before': {
         position: 'absolute',
         top: '0',
-        left: '0',
-        content: 'attr(data-placeholder)',
         color: 'gray',
-        fontSize: 'md',
         pointerEvents: 'none',
+        content: 'attr(data-placeholder)',
       },
     },
   },
-});
-
-const placeholderH1 = css({
-  position: 'relative',
-
-  '.parent:focus-within &': {
-    '&[data-empty=true]': {
-      '&::before': {
-        position: 'absolute',
-        top: '0',
-        left: '5rem',
-        content: 'attr(data-placeholder)',
-        color: 'gray',
-        fontSize: 'lg',
-        pointerEvents: 'none',
+  variants: {
+    tag: {
+      div: {
+        '.parent:focus-within &': {
+          '&[data-empty=true]::before': {
+            left: '0',
+            fontSize: 'md',
+          },
+        },
+      },
+      h1: {
+        '.parent:focus-within &': {
+          '&[data-empty=true]::before': {
+            left: '5rem',
+            fontSize: 'lg',
+          },
+        },
+      },
+      h2: {
+        '.parent:focus-within &': {
+          '&[data-empty=true]::before': {
+            left: '5rem',
+            fontSize: '1.5rem',
+          },
+        },
       },
     },
   },
@@ -52,7 +59,7 @@ const BlockTag = ({ block, index, blockRef, children }: IBlockTag) => {
       <p
         data-placeholder={placeholder.block}
         data-empty={`${block.children.length === 1 && block.children[0].content === ''}`}
-        className={placeholderDiv}
+        className={placeholderStyles({ tag: 'div' })}
         ref={element => {
           // eslint-disable-next-line no-param-reassign
           blockRef.current[index] = element;
@@ -68,7 +75,7 @@ const BlockTag = ({ block, index, blockRef, children }: IBlockTag) => {
       <h1
         data-placeholder={placeholder.h1}
         data-empty={`${block.children.length === 1 && block.children[0].content === ''}`}
-        className={placeholderH1}
+        className={placeholderStyles({ tag: 'h1' })}
         ref={element => {
           // eslint-disable-next-line no-param-reassign
           blockRef.current[index] = element;
@@ -76,6 +83,22 @@ const BlockTag = ({ block, index, blockRef, children }: IBlockTag) => {
       >
         {children}
       </h1>
+    );
+  }
+
+  if (block.type === 'h2') {
+    return (
+      <h2
+        data-placeholder={placeholder.h2}
+        data-empty={`${block.children.length === 1 && block.children[0].content === ''}`}
+        className={placeholderStyles({ tag: 'h2' })}
+        ref={element => {
+          // eslint-disable-next-line no-param-reassign
+          blockRef.current[index] = element;
+        }}
+      >
+        {children}
+      </h2>
     );
   }
 

--- a/src/app/(main)/note/[id]/_components/note-content/block/block.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block/block.tsx
@@ -2,9 +2,9 @@ import { useState, memo, useRef, useEffect } from 'react';
 import { css } from '@/../styled-system/css';
 
 import { ITextBlock } from '@/types/block-type';
-import placeholder from '@/constants/placeholder';
 import handleInput from './_handler/handleInput';
 import handleKeyDown from './_handler/handleKeyDown';
+import BlockTag from './block-tag';
 
 interface IBlockComponent {
   block: ITextBlock;
@@ -17,7 +17,6 @@ interface IBlockComponent {
 }
 
 const blockDiv = css({
-  position: 'relative',
   boxSizing: 'border-box',
   width: 'full',
   minHeight: '2rem',
@@ -25,16 +24,6 @@ const blockDiv = css({
   outline: 'none',
   overflowY: 'hidden',
   flexShrink: 0,
-
-  '&:focus:empty::before': {
-    position: 'absolute',
-    top: '0',
-    left: '0',
-    content: 'attr(data-placeholder)',
-    color: 'gray',
-    fontSize: 'md',
-    pointerEvents: 'none',
-  },
 });
 
 const Block = memo(
@@ -53,33 +42,31 @@ const Block = memo(
         tabIndex={0}
         contentEditable
         suppressContentEditableWarning
-        data-placeholder={placeholder.block}
-        className={blockDiv}
+        className={`parent ${blockDiv}`}
         onInput={event => {
           setIsTyping(true);
-          handleInput(event, index, blockList, setBlockList, blockRef, prevChildNodesLength);
+          handleInput(event, index, blockList, setBlockList, prevChildNodesLength);
         }}
         onKeyDown={event => handleKeyDown(event, index, blockList, setBlockList, blockRef, setIsTyping, setKey)}
-        ref={element => {
-          // eslint-disable-next-line no-param-reassign
-          blockRef.current[index] = element;
-        }}
       >
-        {block.children.map(child => {
-          if (child.type === 'br') {
-            return <br key={Math.random()} />;
-          }
+        <BlockTag block={block} index={index} blockRef={blockRef}>
+          {block.children.length === 1 && block.children[0].content === '' && <br />}
+          {block.children.map(child => {
+            if (child.type === 'br') {
+              return <br key={Math.random()} />;
+            }
 
-          if (child.type === 'text') {
-            return child.content;
-          }
+            if (child.type === 'text') {
+              return child.content;
+            }
 
-          return (
-            <span key={Math.random()} style={child.style}>
-              {child.content}
-            </span>
-          );
-        })}
+            return (
+              <span key={Math.random()} style={child.style}>
+                {child.content}
+              </span>
+            );
+          })}
+        </BlockTag>
       </div>
     );
   },

--- a/src/app/(main)/note/[id]/_components/note-content/block/block.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block/block.tsx
@@ -45,7 +45,7 @@ const Block = memo(
         className={`parent ${blockDiv}`}
         onInput={event => {
           setIsTyping(true);
-          handleInput(event, index, blockList, setBlockList, prevChildNodesLength);
+          handleInput(event, index, blockList, setBlockList, blockRef, prevChildNodesLength);
         }}
         onKeyDown={event => handleKeyDown(event, index, blockList, setBlockList, blockRef, setIsTyping, setKey)}
       >

--- a/src/app/(main)/note/[id]/_components/note-content/block/block.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block/block.tsx
@@ -1,4 +1,4 @@
-import { useState, memo, useRef, useEffect } from 'react';
+import { memo, useRef, useEffect } from 'react';
 import { css } from '@/../styled-system/css';
 
 import { ITextBlock } from '@/types/block-type';
@@ -14,6 +14,7 @@ interface IBlockComponent {
   setBlockList: (blockList: ITextBlock[]) => void;
   isTyping: boolean;
   setIsTyping: (isTyping: boolean) => void;
+  setKey: (key: number) => void;
 }
 
 const blockDiv = css({
@@ -27,8 +28,7 @@ const blockDiv = css({
 });
 
 const Block = memo(
-  ({ block, index, blockRef, blockList, setBlockList, isTyping: _isTyping, setIsTyping }: IBlockComponent) => {
-    const [key, setKey] = useState(Date.now());
+  ({ block, index, blockRef, blockList, setBlockList, isTyping: _isTyping, setIsTyping, setKey }: IBlockComponent) => {
     const prevChildNodesLength = useRef(0);
 
     useEffect(() => {
@@ -37,7 +37,6 @@ const Block = memo(
 
     return (
       <div
-        key={key}
         role="textbox"
         tabIndex={0}
         contentEditable

--- a/src/app/(main)/note/[id]/_components/note-content/block/block.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block/block.tsx
@@ -19,7 +19,7 @@ interface IBlockComponent {
 const blockDiv = css({
   boxSizing: 'border-box',
   width: 'full',
-  minHeight: '2rem',
+  minHeight: '1.5rem',
   height: 'auto',
   outline: 'none',
   overflowY: 'hidden',

--- a/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
@@ -37,6 +37,7 @@ const NoteContent = () => {
     },
   ]);
 
+  const [key, setKey] = useState(Date.now());
   const [isTyping, setIsTyping] = useState(false);
   const blockButtonRef = useRef<(HTMLDivElement | null)[]>([]);
   const blockRef = useRef<(HTMLDivElement | null)[]>([]);
@@ -50,7 +51,7 @@ const NoteContent = () => {
   };
 
   return (
-    <>
+    <div key={key}>
       {blockList.map((block, index) => (
         <div
           role="button"
@@ -79,10 +80,11 @@ const NoteContent = () => {
             setBlockList={setBlockList}
             isTyping={isTyping}
             setIsTyping={setIsTyping}
+            setKey={setKey}
           />
         </div>
       ))}
-    </>
+    </div>
   );
 };
 

--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -1,1 +1,16 @@
 @layer reset, base, tokens, recipes, utilities;
+
+h1 {
+  all: revert;
+  margin: 0;
+}
+
+h2 {
+  all: revert;
+  margin: 0;
+}
+
+h3 {
+  all: revert;
+  margin: 0;
+}

--- a/src/constants/key-name.ts
+++ b/src/constants/key-name.ts
@@ -2,6 +2,7 @@ const keyName = {
   enter: 'Enter',
   backspace: 'Backspace',
   slash: '/',
+  space: ' ',
   arrowLeft: 'ArrowLeft',
   arrowRight: 'ArrowRight',
   arrowUp: 'ArrowUp',

--- a/src/constants/placeholder.ts
+++ b/src/constants/placeholder.ts
@@ -1,5 +1,6 @@
 const placeholder = {
   block: "글을 작성하거나 AI를 사용하려면 '스페이스' 키를, 명령어를 사용하려면 '/' 키를누르세요.",
+  h1: '제목1',
   noteTitle: '새 페이지',
   searchModal: 'Search Page or Keyword',
 };

--- a/src/constants/placeholder.ts
+++ b/src/constants/placeholder.ts
@@ -1,6 +1,8 @@
 const placeholder = {
   block: "글을 작성하거나 AI를 사용하려면 '스페이스' 키를, 명령어를 사용하려면 '/' 키를누르세요.",
   h1: '제목1',
+  h2: '제목2',
+  h3: '제목3',
   noteTitle: '새 페이지',
   searchModal: 'Search Page or Keyword',
 };

--- a/src/types/block-type.ts
+++ b/src/types/block-type.ts
@@ -1,6 +1,6 @@
 export interface ITextBlock {
   id: number;
-  type: 'default' | 'quote' | 'ul' | 'li' | 'toggle';
+  type: 'default' | 'h1' | 'h2' | 'h3' | 'quote' | 'ol' | 'ul';
   children: ITextBlockChild[];
 }
 


### PR DESCRIPTION
## 📝 PR Description

- title 블록 구현

---

## 🔍 Changes Made

- block의 children을 렌더링하는 부분 block tag 컴포넌트로 감싸기
- block tag 컴포넌트에서 block type에 맞는 태그로 block 렌더링
- block type 에 맞는 placeholder 적용
- block에 주던 랜덤 key를 block 전체를 감싸는 div에 적용

---

**설명**: 이 항목에서는 코드의 주요 변경 사항을 나열하여 리뷰어가 코드 수정의 목적을 쉽게 파악할 수 있도록 합니다.
변경된 주요 로직이나 UI 수정 사항이 있다면 구체적으로 설명합니다.

---

## 🔄 Extra Comments

이전에는 React의 가상 DOM과 contentEditable의 DOM 조작이 충돌하는 문제를 해결하기 위해, 개별 블록 컴포넌트에 랜덤한 key 값을 부여했습니다. 이렇게 하면 상태가 업데이트될 때마다 해당 블록이 새로운 요소로 렌더링되어, React의 가상 DOM이 이전 요소와 비교하는 과정에서 발생하는 충돌을 방지할 수 있었습니다.

처음에는 상태가 변경되는 블록의 key 값만 갱신했지만, 업데이트되는 상태가 blockList 전체였기 때문에 다른 블록들도 함께 리렌더링되는 구조였습니다. 이로 인해, 변경된 블록에서는 충돌이 발생하지 않았지만, 다른 블록들에서 충돌이 계속 발생하면서 오류가 발생했습니다.

이를 해결하기 위해, 개별 블록이 아닌 전체 blockList를 감싸는 div에 랜덤한 key 값을 부여하여, 모든 블록이 새로운 요소로 렌더링되도록 수정했습니다.

---

**설명**: 이 PR과 관련된 추가적인 정보를 작성하여 리뷰어가 작업의 맥락을 이해하고, 리뷰에 필요한 내용을 쉽게 참고할 수
있도록 합니다. 이를 통해 PR의 내용을 명확히 전달할 수 있습니다.

---

## 📷 Demo


https://github.com/user-attachments/assets/bdfb59f5-6c52-4ebf-ac92-ea76c22b209b


---

**설명**: UI 변경 사항이 포함된 경우, 변경된 화면을 시각적으로 보여주기 위해 스크린샷이나 동영상을 첨부하면 도움이
됩니다. 리뷰어는 화면 변경 사항을 바로 확인할 수 있어 코드 리뷰가 더 효과적입니다.

---
