### PR TITLE
Fix : 사이드바 자식 페이지 수정 안되던 오류 해결 및 포커스 구현

### DIFF
--- a/src/app/(main)/_components/sidebar/finder/edit-title-modal.tsx
+++ b/src/app/(main)/_components/sidebar/finder/edit-title-modal.tsx
@@ -73,6 +73,7 @@ const EditTitleModal = ({ noteId, closeEditModal }: IEditTitleModal) => {
   const debounceTimer = useRef<NodeJS.Timeout | null>(null);
   const [index, setIndex] = useState(0);
 
+  const inputRef = useRef<HTMLInputElement>(null);
   const editModalRef = useClickOutside(closeEditModal);
 
   useEffect(() => {
@@ -82,6 +83,14 @@ const EditTitleModal = ({ noteId, closeEditModal }: IEditTitleModal) => {
     if (data.node[dataIndex]?.title) {
       setValue(data.node[dataIndex].title);
     }
+
+    setTimeout(() => {
+      if (inputRef.current) {
+        inputRef.current.focus();
+        inputRef.current.select();
+        console.log(inputRef);
+      }
+    }, 0);
   }, []);
 
   useEffect(() => {
@@ -130,7 +139,13 @@ const EditTitleModal = ({ noteId, closeEditModal }: IEditTitleModal) => {
         <div className={iconContainer} onClick={handleSelectorOpen}>
           {data.node[index].icon ?? <PageIcon />}
         </div>
-        <input value={value || ''} onChange={handleChange} onKeyDown={handleKeyDown} className={inputContainer} />
+        <input
+          ref={inputRef}
+          value={value || ''}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          className={inputContainer}
+        />
       </div>
       <div className={IconSelectorContainer}>
         <IconSelector


### PR DESCRIPTION
## 📝 PR Description

- 사이드바 자식 페이지 수정 안되던 오류 해결 및 포커스 구현

---

## 🔍 Changes Made

- 자식 페이지도 이름 수정이 가능하도록 로직 변경
- 이름 수정 모달 생성 시 포커스 및 전체 선택

---

## 🔄 Extra Comments

- 단순히 data.node[index].icon 으로 사용되어 children에 해당되는 node들의 icon을 불러올 수 없음.
- 로직을 findNode 함수를 통해 node를 리턴받고 사용하는 것으로 변경하였습니다.
- focus 및 select로 이름 수정을 더 간편하도록 하였습니다.

---


## 📷 Demo

https://github.com/user-attachments/assets/0be11e7e-f5e6-4e74-84cd-d3abd118f164

--- 