### PR TITLE
feat: list 블록 구현

### DIFF
--- a/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleInput.ts
+++ b/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleInput.ts
@@ -10,7 +10,10 @@ const handleInput = (
   prevChildNodesLength: React.RefObject<number>,
 ) => {
   const updatedBlockList = [...blockList];
-  const target = event.currentTarget.childNodes[0] as HTMLElement;
+  const target =
+    blockList[index].type === 'ul'
+      ? (event.currentTarget.childNodes[0].childNodes[0].childNodes[0] as HTMLElement)
+      : (event.currentTarget.childNodes[0] as HTMLElement);
 
   target.setAttribute('data-empty', 'false');
 
@@ -55,6 +58,8 @@ const handleInput = (
       });
     }
   }
+
+  console.log('currentChildNodeIndex', currentChildNodeIndex);
 
   // 블록에 입력된 내용을 blockList에 반영하는 로직
   updatedBlockList[index].children[currentChildNodeIndex === -1 ? startOffset : currentChildNodeIndex].content =

--- a/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleInput.ts
+++ b/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleInput.ts
@@ -11,7 +11,7 @@ const handleInput = (
 ) => {
   const updatedBlockList = [...blockList];
   const target =
-    blockList[index].type === 'ul'
+    blockList[index].type === 'ul' || blockList[index].type === 'ol'
       ? (event.currentTarget.childNodes[0].childNodes[0].childNodes[0] as HTMLElement)
       : (event.currentTarget.childNodes[0] as HTMLElement);
 
@@ -58,8 +58,6 @@ const handleInput = (
       });
     }
   }
-
-  console.log('currentChildNodeIndex', currentChildNodeIndex);
 
   // 블록에 입력된 내용을 blockList에 반영하는 로직
   updatedBlockList[index].children[currentChildNodeIndex === -1 ? startOffset : currentChildNodeIndex].content =

--- a/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleKeyDown.ts
+++ b/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleKeyDown.ts
@@ -332,6 +332,14 @@ const turnIntoH3 = (index: number, blockList: ITextBlock[], setBlockList: (block
   setBlockList(updatedBlockList);
 };
 
+const turnIntoUl = (index: number, blockList: ITextBlock[], setBlockList: (blockList: ITextBlock[]) => void) => {
+  const updatedBlockList = [...blockList];
+  updatedBlockList[index].type = 'ul';
+  updatedBlockList[index].children[0].content = (updatedBlockList[index].children[0].content as string).substring(1);
+
+  setBlockList(updatedBlockList);
+};
+
 const handleKeyDown = (
   event: React.KeyboardEvent<HTMLDivElement>,
   index: number,
@@ -372,6 +380,11 @@ const handleKeyDown = (
     // 첫 블록 첫 커서에서 백스페이스 방지
     if (index === 0 && (currentChildNodeIndex === -1 || currentChildNodeIndex === 0) && startOffset === 0) {
       event.preventDefault();
+      if (blockList[index].type === 'ul') {
+        const updatedBlockList = [...blockList];
+        updatedBlockList[index].type = 'default';
+        setBlockList(updatedBlockList);
+      }
       return;
     }
 
@@ -383,7 +396,14 @@ const handleKeyDown = (
 
       if (startOffset === 0) {
         // 블록 합치기 로직
-        mergeBlock(index, blockList, setBlockList);
+        if (blockList[index].type === 'ul') {
+          // ul이나 ol일 때는 블록을 합치는 대신 블록을 default로 변경
+          const updatedBlockList = [...blockList];
+          updatedBlockList[index].type = 'default';
+          setBlockList(updatedBlockList);
+        } else {
+          mergeBlock(index, blockList, setBlockList);
+        }
       } else {
         // 줄 합치기 로직
         const updatedBlockList = [...blockList];
@@ -411,7 +431,13 @@ const handleKeyDown = (
       setIsTyping(false);
       setKey(Math.random());
       if (currentChildNodeIndex <= 0) {
-        mergeBlock(index, blockList, setBlockList);
+        if (blockList[index].type === 'ul') {
+          const updatedBlockList = [...blockList];
+          updatedBlockList[index].type = 'default';
+          setBlockList(updatedBlockList);
+        } else {
+          mergeBlock(index, blockList, setBlockList);
+        }
       } else if (currentChildNodeIndex > 0) {
         mergeLine(index, currentChildNodeIndex, blockList, setBlockList);
       }
@@ -472,6 +498,20 @@ const handleKeyDown = (
       setIsTyping(false);
       setKey(Math.random());
       turnIntoH3(index, blockList, setBlockList);
+    }
+
+    // ul로 전환
+    if (
+      currentChildNodeIndex === 0 &&
+      startOffset === 1 &&
+      startContainer.textContent &&
+      startContainer.textContent[0] === '-' &&
+      blockList[index].type !== 'ul'
+    ) {
+      event.preventDefault();
+      setIsTyping(false);
+      setKey(Math.random());
+      turnIntoUl(index, blockList, setBlockList);
     }
   }
 };

--- a/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleKeyDown.ts
+++ b/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleKeyDown.ts
@@ -392,13 +392,14 @@ const handleKeyDown = (
         ? childNodes.indexOf(startContainer.parentNode as HTMLElement)
         : childNodes.indexOf(startContainer as HTMLElement);
 
-    // 첫 블록 첫 커서에서 백스페이스 방지
+    // 첫 블록 첫 커서일 때
     if (index === 0 && (currentChildNodeIndex === -1 || currentChildNodeIndex === 0) && startOffset === 0) {
       event.preventDefault();
       setIsTyping(false);
       setKey(Math.random());
 
-      if (blockList[index].type === 'ul' || blockList[index].type === 'ol') {
+      // default 블록이 아닐 때는 default로 변경
+      if (blockList[index].type !== 'default') {
         const updatedBlockList = [...blockList];
         updatedBlockList[index].type = 'default';
         setBlockList(updatedBlockList);
@@ -449,7 +450,7 @@ const handleKeyDown = (
       setIsTyping(false);
       setKey(Math.random());
       if (currentChildNodeIndex <= 0) {
-        if (blockList[index].type === 'ul' || blockList[index].type === 'ol') {
+        if (blockList[index].type !== 'default') {
           const updatedBlockList = [...blockList];
           updatedBlockList[index].type = 'default';
           setBlockList(updatedBlockList);

--- a/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleKeyDown.ts
+++ b/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleKeyDown.ts
@@ -415,8 +415,8 @@ const handleKeyDown = (
 
       if (startOffset === 0) {
         // 블록 합치기 로직
-        if (blockList[index].type === 'ul' || blockList[index].type === 'ol') {
-          // ul이나 ol일 때는 블록을 합치는 대신 블록을 default로 변경
+        if (blockList[index].type !== 'default') {
+          // default 블록이 아닐 때는 블록을 합치는 대신 블록을 default로 변경
           const updatedBlockList = [...blockList];
           updatedBlockList[index].type = 'default';
           setBlockList(updatedBlockList);

--- a/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleKeyDown.ts
+++ b/src/app/(main)/note/[id]/_components/note-content/block/_handler/handleKeyDown.ts
@@ -340,6 +340,21 @@ const turnIntoUl = (index: number, blockList: ITextBlock[], setBlockList: (block
   setBlockList(updatedBlockList);
 };
 
+const turnIntoOl = (
+  index: number,
+  blockList: ITextBlock[],
+  setBlockList: (blockList: ITextBlock[]) => void,
+  offset: number,
+) => {
+  const updatedBlockList = [...blockList];
+  updatedBlockList[index].type = 'ol';
+  updatedBlockList[index].children[0].content = (updatedBlockList[index].children[0].content as string).substring(
+    offset,
+  );
+
+  setBlockList(updatedBlockList);
+};
+
 const handleKeyDown = (
   event: React.KeyboardEvent<HTMLDivElement>,
   index: number,
@@ -380,7 +395,10 @@ const handleKeyDown = (
     // 첫 블록 첫 커서에서 백스페이스 방지
     if (index === 0 && (currentChildNodeIndex === -1 || currentChildNodeIndex === 0) && startOffset === 0) {
       event.preventDefault();
-      if (blockList[index].type === 'ul') {
+      setIsTyping(false);
+      setKey(Math.random());
+
+      if (blockList[index].type === 'ul' || blockList[index].type === 'ol') {
         const updatedBlockList = [...blockList];
         updatedBlockList[index].type = 'default';
         setBlockList(updatedBlockList);
@@ -396,7 +414,7 @@ const handleKeyDown = (
 
       if (startOffset === 0) {
         // 블록 합치기 로직
-        if (blockList[index].type === 'ul') {
+        if (blockList[index].type === 'ul' || blockList[index].type === 'ol') {
           // ul이나 ol일 때는 블록을 합치는 대신 블록을 default로 변경
           const updatedBlockList = [...blockList];
           updatedBlockList[index].type = 'default';
@@ -431,7 +449,7 @@ const handleKeyDown = (
       setIsTyping(false);
       setKey(Math.random());
       if (currentChildNodeIndex <= 0) {
-        if (blockList[index].type === 'ul') {
+        if (blockList[index].type === 'ul' || blockList[index].type === 'ol') {
           const updatedBlockList = [...blockList];
           updatedBlockList[index].type = 'default';
           setBlockList(updatedBlockList);
@@ -512,6 +530,20 @@ const handleKeyDown = (
       setIsTyping(false);
       setKey(Math.random());
       turnIntoUl(index, blockList, setBlockList);
+    }
+
+    // ol로 전환
+    if (
+      currentChildNodeIndex === 0 &&
+      startContainer.textContent &&
+      startContainer.textContent[startOffset - 1] === '.' &&
+      /^\d+$/.test(startContainer.textContent.slice(0, startOffset - 1)) &&
+      blockList[index].type !== 'ol'
+    ) {
+      event.preventDefault();
+      setIsTyping(false);
+      setKey(Math.random());
+      turnIntoOl(index, blockList, setBlockList, startOffset);
     }
   }
 };

--- a/src/app/(main)/note/[id]/_components/note-content/block/block-tag.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block/block-tag.tsx
@@ -25,10 +25,9 @@ const placeholderStyles = cva({
   },
   variants: {
     tag: {
-      div: {
+      p: {
         '.parent:focus-within &': {
           '&[data-empty=true]::before': {
-            left: '0',
             fontSize: 'md',
           },
         },
@@ -67,7 +66,7 @@ const BlockTag = ({ block, index, blockRef, children }: IBlockTag) => {
       <p
         data-placeholder={placeholder.block}
         data-empty={`${block.children.length === 1 && block.children[0].content === ''}`}
-        className={placeholderStyles({ tag: 'div' })}
+        className={placeholderStyles({ tag: 'p' })}
         ref={element => {
           // eslint-disable-next-line no-param-reassign
           blockRef.current[index] = element;
@@ -123,6 +122,26 @@ const BlockTag = ({ block, index, blockRef, children }: IBlockTag) => {
       >
         {children}
       </h3>
+    );
+  }
+
+  if (block.type === 'ul') {
+    return (
+      <ul>
+        <li>
+          <p
+            data-placeholder={placeholder.li}
+            data-empty={`${block.children.length === 1 && block.children[0].content === ''}`}
+            className={placeholderStyles({ tag: 'p' })}
+            ref={element => {
+              // eslint-disable-next-line no-param-reassign
+              blockRef.current[index] = element;
+            }}
+          >
+            {children}
+          </p>
+        </li>
+      </ul>
     );
   }
 

--- a/src/app/(main)/note/[id]/_components/note-content/block/block-tag.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block/block-tag.tsx
@@ -5,6 +5,7 @@ import placeholder from '@/constants/placeholder';
 
 interface IBlockTag {
   block: ITextBlock;
+  blockList: ITextBlock[];
   index: number;
   blockRef: React.RefObject<(HTMLDivElement | null)[]>;
   children: React.ReactNode[];
@@ -60,7 +61,7 @@ const placeholderStyles = cva({
   },
 });
 
-const BlockTag = ({ block, index, blockRef, children }: IBlockTag) => {
+const BlockTag = ({ block, blockList, index, blockRef, children }: IBlockTag) => {
   if (block.type === 'default') {
     return (
       <p
@@ -142,6 +143,38 @@ const BlockTag = ({ block, index, blockRef, children }: IBlockTag) => {
           </p>
         </li>
       </ul>
+    );
+  }
+
+  if (block.type === 'ol') {
+    let startNumber = 1;
+
+    blockList.forEach((item, idx) => {
+      if (idx >= index) return;
+
+      if (item.type === 'ol') {
+        startNumber += 1;
+      } else {
+        startNumber = 1;
+      }
+    });
+
+    return (
+      <ol start={startNumber}>
+        <li>
+          <p
+            data-placeholder={placeholder.li}
+            data-empty={`${block.children.length === 1 && block.children[0].content === ''}`}
+            className={placeholderStyles({ tag: 'p' })}
+            ref={element => {
+              // eslint-disable-next-line no-param-reassign
+              blockRef.current[index] = element;
+            }}
+          >
+            {children}
+          </p>
+        </li>
+      </ol>
     );
   }
 

--- a/src/app/(main)/note/[id]/_components/note-content/block/block.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block/block.tsx
@@ -48,7 +48,7 @@ const Block = memo(
         }}
         onKeyDown={event => handleKeyDown(event, index, blockList, setBlockList, blockRef, setIsTyping, setKey)}
       >
-        <BlockTag block={block} index={index} blockRef={blockRef}>
+        <BlockTag block={block} blockList={blockList} index={index} blockRef={blockRef}>
           {block.children.length === 1 && block.children[0].content === '' && <br />}
           {block.children.map(child => {
             if (child.type === 'br') {

--- a/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
@@ -13,6 +13,7 @@ const blockContainer = css({
   display: 'flex',
   flexDirection: 'row',
   px: '5rem',
+  mb: '0.5rem',
 });
 
 const NoteContent = () => {

--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -14,3 +14,9 @@ h3 {
   all: revert;
   margin: 0;
 }
+
+ul {
+  all: revert;
+  margin: 0;
+  padding: 0 0 0 20px;
+}

--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -20,3 +20,9 @@ ul {
   margin: 0;
   padding: 0 0 0 20px;
 }
+
+ol {
+  all: revert;
+  margin: 0;
+  padding: 0 0 0 20px;
+}

--- a/src/constants/placeholder.ts
+++ b/src/constants/placeholder.ts
@@ -3,6 +3,7 @@ const placeholder = {
   h1: '제목1',
   h2: '제목2',
   h3: '제목3',
+  li: '리스트',
   noteTitle: '새 페이지',
   searchModal: 'Search Page or Keyword',
 };


### PR DESCRIPTION
## 📝 PR Description

- list 블록 구현

---

## 🔍 Changes Made

- `-` 입력 후 스페이스바 입력 시 블록 타입을 ul로 변경하는 로직 추가
- 숫자 + `.` 입력 후 스페이스바 입력 시 블록 타입을 ol로 변경하는 로직 추가
- block tag 컴포넌트에 ol, ul 타입을 렌더링 하는 로직 추가
- 기본 타입이 아닌 블록에서 맨 앞에서 백스페이스를 입력하면, 해당 블록이 이전 블록과 합쳐지는 대신 기본 타입의 블록으로 변경하는 로직 추가

---

**설명**: 이 항목에서는 코드의 주요 변경 사항을 나열하여 리뷰어가 코드 수정의 목적을 쉽게 파악할 수 있도록 합니다.
변경된 주요 로직이나 UI 수정 사항이 있다면 구체적으로 설명합니다.

---

## 🔄 Extra Comments

- ol 타입의 블록은 순서 1부터 순서대로 순서가 올라갑니다.
- 연속되지 않는 ol타입의 블록은 1부터 시작합니다.

---

**설명**: 이 PR과 관련된 추가적인 정보를 작성하여 리뷰어가 작업의 맥락을 이해하고, 리뷰에 필요한 내용을 쉽게 참고할 수
있도록 합니다. 이를 통해 PR의 내용을 명확히 전달할 수 있습니다.

---

## 📷 Demo


https://github.com/user-attachments/assets/6e674955-b924-4672-9733-52f17affc06d


---

**설명**: UI 변경 사항이 포함된 경우, 변경된 화면을 시각적으로 보여주기 위해 스크린샷이나 동영상을 첨부하면 도움이
됩니다. 리뷰어는 화면 변경 사항을 바로 확인할 수 있어 코드 리뷰가 더 효과적입니다.

---
