### PR TITLE
feat: 공유된 노트 UI 구현 

### DIFF
--- a/src/app/(main)/_components/sidebar/sidebar.tsx
+++ b/src/app/(main)/_components/sidebar/sidebar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
 import { css } from '@/../styled-system/css';
 
 import ProfileCard from './profile/profile-card';
@@ -36,6 +37,11 @@ const Sidebar = () => {
   const sidebarWidth = savedWidth ? parseFloat(savedWidth) : startWidth;
   const sideBarRef = useRef<HTMLDivElement>(null);
   const [isOpen, setIsOpen] = useState(true);
+  const pathname = usePathname();
+
+  if (pathname.startsWith('/note/share')) {
+    return null;
+  }
 
   return (
     <div className={sideBarContainer}>

--- a/src/app/(main)/note/[id]/_components/header.tsx
+++ b/src/app/(main)/note/[id]/_components/header.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+import { useRouter, useParams } from 'next/navigation';
 import { css } from '@/../styled-system/css';
 
 import LeftArrowIcon from '@/icons/left-arrow-icon';
@@ -7,7 +9,6 @@ import RightArrowIcon from '@/icons/right-arrow-icon';
 import HorizonDotIcon from '@/icons/horizon-dot-icon';
 import DropDown from '@/components/dropdown/dropdown';
 import TrashIcon from '@/icons/trash-icon';
-import { useState } from 'react';
 
 const headerConatiner = css({
   boxSizing: 'border-box',
@@ -30,11 +31,18 @@ const rightItemsConatiner = css({
   gap: 'small',
 });
 
+const shareButton = css({
+  cursor: 'pointer',
+});
+
 const dropDownButton = css({
   cursor: 'pointer',
 });
 
 const Header = () => {
+  const router = useRouter();
+  const params = useParams();
+  const noteId = params.id as string;
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const openSettingDropdown = () => {
@@ -45,6 +53,10 @@ const Header = () => {
     setIsDropdownOpen(false);
   };
 
+  const sharePage = () => {
+    router.push(`/note/share/${noteId}`);
+  };
+
   return (
     <div className={headerConatiner}>
       <div className={leftItemsConatiner}>
@@ -52,8 +64,10 @@ const Header = () => {
         <RightArrowIcon />
       </div>
       <div className={rightItemsConatiner}>
-        <div>공유</div>
-        <div className={dropDownButton} onClick={openSettingDropdown}>
+        <button type="button" className={shareButton} onClick={sharePage}>
+          공유
+        </button>
+        <button type="button" className={dropDownButton} onClick={openSettingDropdown}>
           <HorizonDotIcon />
           <DropDown handleClose={closeSettingDropdown}>
             <DropDown.Menu isOpen={isDropdownOpen} top="0.5rem" right="0">
@@ -63,7 +77,7 @@ const Header = () => {
               </DropDown.Item>
             </DropDown.Menu>
           </DropDown>
-        </div>
+        </button>
       </div>
     </div>
   );

--- a/src/app/(main)/note/[id]/_components/note-content/block/block-html-tag.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block/block-html-tag.tsx
@@ -61,7 +61,7 @@ const placeholderStyles = cva({
   },
 });
 
-const BlockTag = ({ block, blockList, index, blockRef, children }: IBlockTag) => {
+const BlockHTMLTag = ({ block, blockList, index, blockRef, children }: IBlockTag) => {
   if (block.type === 'default') {
     return (
       <p
@@ -192,4 +192,4 @@ const BlockTag = ({ block, blockList, index, blockRef, children }: IBlockTag) =>
   return null;
 };
 
-export default BlockTag;
+export default BlockHTMLTag;

--- a/src/app/(main)/note/[id]/_components/note-content/block/block.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block/block.tsx
@@ -6,7 +6,7 @@ import ISelectionPosition from '@/types/selection-position';
 import handleInput from './_handler/handleInput';
 import handleKeyDown from './_handler/handleKeyDown';
 import handleMouseLeave from './_handler/handleMouseLeave';
-import BlockTag from './block-tag';
+import BlockHTMLTag from './block-html-tag';
 import handleMouseDown from './_handler/handleMouseDown';
 import handleMouseMove from './_handler/handleMouseMove';
 import SlashMenu from './slash-menu';
@@ -134,7 +134,7 @@ const Block = memo(
           handleMouseLeave(index, isDragging, isUp, blockRef, selectionStartPosition, selectionEndPosition)
         }
       >
-        <BlockTag block={block} blockList={blockList} index={index} blockRef={blockRef}>
+        <BlockHTMLTag block={block} blockList={blockList} index={index} blockRef={blockRef}>
           {block.children.length === 1 && block.children[0].content === '' && <br />}
           {block.children.map(child => {
             if (child.type === 'br') {
@@ -151,7 +151,7 @@ const Block = memo(
               </span>
             );
           })}
-        </BlockTag>
+        </BlockHTMLTag>
         {isSlashMenuOpen[index] && (
           <SlashMenu
             position={slashMenuPosition}

--- a/src/app/(main)/note/share/[id]/_components/block-html-tag.tsx
+++ b/src/app/(main)/note/share/[id]/_components/block-html-tag.tsx
@@ -7,7 +7,7 @@ interface IBlockTag {
   children: React.ReactNode[];
 }
 
-const BlockTag = ({ block, blocks, index, children }: IBlockTag) => {
+const BlockHTMLTag = ({ block, blocks, index, children }: IBlockTag) => {
   if (block.type === 'default') {
     return <p>{children}</p>;
   }
@@ -67,4 +67,4 @@ const BlockTag = ({ block, blocks, index, children }: IBlockTag) => {
   return null;
 };
 
-export default BlockTag;
+export default BlockHTMLTag;

--- a/src/app/(main)/note/share/[id]/_components/block-tag.tsx
+++ b/src/app/(main)/note/share/[id]/_components/block-tag.tsx
@@ -1,0 +1,70 @@
+import { ITextBlock } from '@/types/block-type';
+
+interface IBlockTag {
+  block: ITextBlock;
+  blocks: ITextBlock[];
+  index: number;
+  children: React.ReactNode[];
+}
+
+const BlockTag = ({ block, blocks, index, children }: IBlockTag) => {
+  if (block.type === 'default') {
+    return <p>{children}</p>;
+  }
+
+  if (block.type === 'h1') {
+    return <h1>{children}</h1>;
+  }
+
+  if (block.type === 'h2') {
+    return <h2>{children}</h2>;
+  }
+
+  if (block.type === 'h3') {
+    return <h3>{children}</h3>;
+  }
+
+  if (block.type === 'ul') {
+    return (
+      <ul>
+        <li>
+          <p>{children}</p>
+        </li>
+      </ul>
+    );
+  }
+
+  if (block.type === 'ol') {
+    let startNumber = 1;
+
+    blocks.forEach((item, idx) => {
+      if (idx >= index) return;
+
+      if (item.type === 'ol') {
+        startNumber += 1;
+      } else {
+        startNumber = 1;
+      }
+    });
+
+    return (
+      <ol start={startNumber}>
+        <li>
+          <p>{children}</p>
+        </li>
+      </ol>
+    );
+  }
+
+  if (block.type === 'quote') {
+    return (
+      <blockquote>
+        <p>{children}</p>
+      </blockquote>
+    );
+  }
+
+  return null;
+};
+
+export default BlockTag;

--- a/src/app/(main)/note/share/[id]/_components/content.tsx
+++ b/src/app/(main)/note/share/[id]/_components/content.tsx
@@ -1,7 +1,7 @@
 import { css } from '@/../styled-system/css';
 
 import { ITextBlock } from '@/types/block-type';
-import BlockTag from './block-tag';
+import BlockHTMLTag from './block-html-tag';
 
 const container = css({
   display: 'flex',
@@ -211,7 +211,7 @@ const Content = () => {
     <div className={container}>
       {blocks.map((block, index) => (
         <div key={block.id} className={blockDiv}>
-          <BlockTag block={block} blocks={blocks} index={index}>
+          <BlockHTMLTag block={block} blocks={blocks} index={index}>
             {block.children.map((child, idx) => {
               if (child.type === 'br') {
                 return <br key={idx} />;
@@ -227,7 +227,7 @@ const Content = () => {
                 </span>
               );
             })}
-          </BlockTag>
+          </BlockHTMLTag>
         </div>
       ))}
     </div>

--- a/src/app/(main)/note/share/[id]/_components/content.tsx
+++ b/src/app/(main)/note/share/[id]/_components/content.tsx
@@ -1,0 +1,237 @@
+import { css } from '@/../styled-system/css';
+
+import { ITextBlock } from '@/types/block-type';
+import BlockTag from './block-tag';
+
+const container = css({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '44.5rem',
+  mt: 'base',
+});
+
+const blockDiv = css({
+  pointerEvents: 'auto',
+  boxSizing: 'border-box',
+  width: 'full',
+  minHeight: '1.5rem',
+  height: 'auto',
+  outline: 'none',
+  overflowY: 'hidden',
+  flexShrink: 0,
+  userSelect: 'none',
+  mb: 'tiny',
+});
+
+const Content = () => {
+  const blocks: ITextBlock[] = [
+    {
+      id: 1,
+      type: 'h1',
+      children: [
+        {
+          type: 'text',
+          style: {
+            fontStyle: 'italic',
+            fontWeight: 'bold',
+            textDecoration: 'underline',
+            color: 'black',
+            backgroundColor: 'white',
+            width: '100%',
+            height: 'auto',
+            borderRadius: 4,
+          },
+          content: '제목1 입니다.',
+        },
+      ],
+    },
+    {
+      id: 2,
+      type: 'default',
+      children: [
+        {
+          type: 'text',
+          style: {
+            fontStyle: 'normal',
+            fontWeight: 'regular',
+            textDecoration: 'none',
+            color: 'black',
+            backgroundColor: 'white',
+            width: '100%',
+            height: 'auto',
+            borderRadius: 0,
+          },
+          content: '기본 블록 입니다.',
+        },
+      ],
+    },
+    {
+      id: 3,
+      type: 'quote',
+      children: [
+        {
+          type: 'text',
+          style: {
+            fontStyle: 'italic',
+            fontWeight: 'regular',
+            textDecoration: 'none',
+            color: 'black',
+            backgroundColor: 'grey',
+            width: '100%',
+            height: 'auto',
+            borderRadius: 8,
+          },
+          content: '인용문입니다.',
+        },
+      ],
+    },
+    {
+      id: 4,
+      type: 'h2',
+      children: [
+        {
+          type: 'text',
+          style: {
+            fontStyle: 'normal',
+            fontWeight: 'bold',
+            textDecoration: 'underline',
+            color: 'black',
+            backgroundColor: 'white',
+            width: '100%',
+            height: 'auto',
+            borderRadius: 4,
+          },
+          content: '제목2 입니다.',
+        },
+      ],
+    },
+    {
+      id: 5,
+      type: 'ul',
+      children: [
+        {
+          type: 'span',
+          style: {
+            fontStyle: 'normal',
+            fontWeight: 'bold',
+            textDecoration: 'none',
+            color: 'black',
+            backgroundColor: 'white',
+            width: '100%',
+            height: 'auto',
+            borderRadius: 0,
+          },
+          content: '순서가 없는 리스트 1 bold',
+        },
+      ],
+    },
+    {
+      id: 6,
+      type: 'ul',
+      children: [
+        {
+          type: 'span',
+          style: {
+            fontStyle: 'italic',
+            fontWeight: 'regular',
+            textDecoration: 'none',
+            color: 'black',
+            backgroundColor: 'white',
+            width: '100%',
+            height: 'auto',
+            borderRadius: 0,
+          },
+          content: '순서가 없는 리스트 2 italic',
+        },
+      ],
+    },
+    {
+      id: 7,
+      type: 'ol',
+      children: [
+        {
+          type: 'text',
+          style: {
+            fontStyle: 'normal',
+            fontWeight: 'bold',
+            textDecoration: 'none',
+            color: 'black',
+            backgroundColor: 'white',
+            width: '100%',
+            height: 'auto',
+            borderRadius: 0,
+          },
+          content: '순서가 있는 리스트 1',
+        },
+      ],
+    },
+    {
+      id: 8,
+      type: 'ol',
+      children: [
+        {
+          type: 'text',
+          style: {
+            fontStyle: 'italic',
+            fontWeight: 'regular',
+            textDecoration: 'none',
+            color: 'black',
+            backgroundColor: 'white',
+            width: '100%',
+            height: 'auto',
+            borderRadius: 0,
+          },
+          content: '순서가 있는 리스트 2',
+        },
+      ],
+    },
+    {
+      id: 9,
+      type: 'default',
+      children: [
+        {
+          type: 'span',
+          style: {
+            fontStyle: 'normal',
+            fontWeight: 'regular',
+            textDecoration: 'none',
+            color: 'red',
+            backgroundColor: 'rgba(161, 161, 161, 0.5)',
+            width: '100%',
+            height: 'auto',
+            borderRadius: 0,
+          },
+          content: '코드 블록 입니다.',
+        },
+      ],
+    },
+  ];
+
+  return (
+    <div className={container}>
+      {blocks.map((block, index) => (
+        <div key={block.id} className={blockDiv}>
+          <BlockTag block={block} blocks={blocks} index={index}>
+            {block.children.map((child, idx) => {
+              if (child.type === 'br') {
+                return <br key={idx} />;
+              }
+
+              if (child.type === 'text') {
+                return child.content;
+              }
+
+              return (
+                <span key={idx} style={child.style}>
+                  {child.content}
+                </span>
+              );
+            })}
+          </BlockTag>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Content;

--- a/src/app/(main)/note/share/[id]/_components/header.tsx
+++ b/src/app/(main)/note/share/[id]/_components/header.tsx
@@ -66,6 +66,7 @@ const tagContainer = css({
   justifyContent: 'start',
   gap: 'small',
   userSelect: 'none',
+  mt: 'base',
 });
 
 const typeContainer = css({
@@ -77,7 +78,6 @@ const typeContainer = css({
   width: '10rem',
   height: 'auto',
   borderRadius: '0.2rem',
-  px: 'tiny',
   gap: 'tiny',
   color: 'grey',
   cursor: 'pointer',
@@ -130,7 +130,7 @@ const Header = ({ noteData }: IHeader) => {
   return (
     <div className={container}>
       {noteData.cover && <div className={cover} style={{ backgroundColor: noteData.cover }} />}
-      {noteData.icon && <div className={icon({ hasCover: !!noteData.cover })}>{noteData.icon}</div>}
+      <div className={icon({ hasCover: !!noteData.cover })}>{noteData.icon && noteData.icon}</div>
       <div className={title}>{noteData.title}</div>
       <div className={tagContainer}>
         <div className={typeContainer}>

--- a/src/app/(main)/note/share/[id]/_components/header.tsx
+++ b/src/app/(main)/note/share/[id]/_components/header.tsx
@@ -15,16 +15,18 @@ interface IHeader {
 }
 
 const container = css({
+  position: 'relative',
   display: 'flex',
   flexDirection: 'column',
   width: '44.5rem',
+  pt: '6rem',
 });
 
 const cover = css({
-  position: 'fixed',
+  position: 'absolute',
   left: '0',
   top: '0',
-  width: '100%',
+  width: '100vw',
   height: '15.5rem',
   zIndex: -1,
 });
@@ -37,13 +39,12 @@ const icon = cva({
     width: '4rem',
     height: '5.5rem',
     fontSize: 'xl',
-    mt: 'large',
   },
   variants: {
     hasCover: {
-      true: { mt: '12rem' },
+      true: { mt: '6rem' },
       false: {
-        mt: 'large',
+        mt: '0',
       },
     },
   },
@@ -128,23 +129,38 @@ const tagBox = cva({
 
 const Header = ({ noteData }: IHeader) => {
   return (
-    <div className={container}>
+    <>
       {noteData.cover && <div className={cover} style={{ backgroundColor: noteData.cover }} />}
-      <div className={icon({ hasCover: !!noteData.cover })}>{noteData.icon && noteData.icon}</div>
-      <div className={title}>{noteData.title}</div>
-      <div className={tagContainer}>
-        <div className={typeContainer}>
-          <TagIcon />
-          태그
-        </div>
-        <div className={tagBoxContainer}>
-          {noteData.tags.map(tag => (
-            <div className={tagBox({ color: tag.color as keyof typeof LineColor })}>{tag.name}</div>
-          ))}
+      <div className={container}>
+        {(noteData.cover || noteData.icon) && (
+          <div className={icon({ hasCover: !!noteData.cover })}>{noteData.icon && noteData.icon}</div>
+        )}
+        <div className={title}>{noteData.title}</div>
+        <div className={tagContainer}>
+          <div className={typeContainer}>
+            <TagIcon />
+            태그
+          </div>
+          <div className={tagBoxContainer}>
+            {noteData.tags.length !== 0 ? (
+              noteData.tags.map(tag => (
+                <div key={tag.name} className={tagBox({ color: tag.color as keyof typeof LineColor })}>
+                  {tag.name}
+                </div>
+              ))
+            ) : (
+              <div>비어있음</div>
+            )}
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 };
 
 export default Header;
+
+// cover 있고 아이콘 있으면 아이콘 있음
+// cover 없고 아이콘 있으면 아이콘 있음
+// cover 있고 아이콘 없으면 아이콘 있음
+// cover 없고 아이콘 없으면 아이콘 없음

--- a/src/app/(main)/note/share/[id]/_components/header.tsx
+++ b/src/app/(main)/note/share/[id]/_components/header.tsx
@@ -1,0 +1,150 @@
+import { css, cva } from '@/../styled-system/css';
+
+import { ITextBlock } from '@/types/block-type';
+import LineColor from '@/constants/line-color';
+import TagIcon from '@/icons/tag-icon';
+
+interface IHeader {
+  noteData: {
+    title: string;
+    icon: string;
+    cover: string;
+    tags: { name: string; color: string }[];
+    blocks: ITextBlock[];
+  };
+}
+
+const container = css({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '44.5rem',
+});
+
+const cover = css({
+  position: 'fixed',
+  left: '0',
+  top: '0',
+  width: '100%',
+  height: '15.5rem',
+  zIndex: -1,
+});
+
+const icon = cva({
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '4rem',
+    height: '5.5rem',
+    fontSize: 'xl',
+    mt: 'large',
+  },
+  variants: {
+    hasCover: {
+      true: { mt: '12rem' },
+      false: {
+        mt: 'large',
+      },
+    },
+  },
+});
+
+const title = css({
+  fontSize: 'lg',
+  fontWeight: 'bold',
+  color: 'black',
+  mt: 'base',
+});
+
+const tagContainer = css({
+  minHeight: '2rem',
+  height: 'auto',
+  width: '44.5rem',
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'start',
+  justifyContent: 'start',
+  gap: 'small',
+  userSelect: 'none',
+});
+
+const typeContainer = css({
+  minHeight: '2.5rem',
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'start',
+  width: '10rem',
+  height: 'auto',
+  borderRadius: '0.2rem',
+  px: 'tiny',
+  gap: 'tiny',
+  color: 'grey',
+  cursor: 'pointer',
+});
+
+const tagBoxContainer = css({
+  minHeight: '2.5rem',
+  height: 'auto',
+  width: '100%',
+  maxWidth: '35rem',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'start',
+  gap: 'tiny',
+  cursor: 'pointer',
+  padding: 'tiny',
+  borderRadius: '0.2rem',
+  color: 'grey',
+  flexWrap: 'wrap',
+});
+
+const tagBox = cva({
+  base: {
+    height: '1.2rem',
+    width: 'auto',
+    color: 'white',
+    fontSize: '0.75rem',
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: '0.25rem',
+    px: 'tiny',
+    gap: 'tiny',
+    cursor: 'default',
+  },
+  variants: {
+    color: {
+      LINE_ONE: { backgroundColor: 'lineOne' },
+      LINE_TWO: { backgroundColor: 'lineTwo' },
+      LINE_THREE: { backgroundColor: 'lineThree' },
+      LINE_FOUR: { backgroundColor: 'lineFour' },
+      LINE_FIVE: { backgroundColor: 'lineFive' },
+      LINE_SIX: { backgroundColor: 'lineSix' },
+    },
+  },
+});
+
+const Header = ({ noteData }: IHeader) => {
+  return (
+    <div className={container}>
+      {noteData.cover && <div className={cover} style={{ backgroundColor: noteData.cover }} />}
+      {noteData.icon && <div className={icon({ hasCover: !!noteData.cover })}>{noteData.icon}</div>}
+      <div className={title}>{noteData.title}</div>
+      <div className={tagContainer}>
+        <div className={typeContainer}>
+          <TagIcon />
+          태그
+        </div>
+        <div className={tagBoxContainer}>
+          {noteData.tags.map(tag => (
+            <div className={tagBox({ color: tag.color as keyof typeof LineColor })}>{tag.name}</div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Header;

--- a/src/app/(main)/note/share/[id]/page.tsx
+++ b/src/app/(main)/note/share/[id]/page.tsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 import { cookies } from 'next/headers';
 
 import Header from './_components/header';
+import Content from './_components/content';
 
 const container = css({
   display: 'flex',
@@ -12,6 +13,7 @@ const container = css({
   justifyContent: 'center',
   width: '100%',
   height: '100%',
+  pb: '13rem',
 });
 
 const SharedNote = async ({ params }: { params: Promise<{ id: string }> }) => {
@@ -31,7 +33,7 @@ const SharedNote = async ({ params }: { params: Promise<{ id: string }> }) => {
   return (
     <div className={container}>
       <Header noteData={noteData} />
-      <div>contents</div>
+      <Content />
     </div>
   );
 };

--- a/src/app/(main)/note/share/[id]/page.tsx
+++ b/src/app/(main)/note/share/[id]/page.tsx
@@ -1,0 +1,39 @@
+import { css } from '@/../styled-system/css';
+
+import axios from 'axios';
+import { cookies } from 'next/headers';
+
+import Header from './_components/header';
+
+const container = css({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '100%',
+  height: '100%',
+});
+
+const SharedNote = async ({ params }: { params: Promise<{ id: string }> }) => {
+  const cookie = await cookies();
+  const accessToken = cookie?.get('accessToken')?.value;
+  const { id } = await params;
+
+  const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/documents/${id}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  const noteData = response.data;
+
+  return (
+    <div className={container}>
+      <Header noteData={noteData} />
+      <div>contents</div>
+    </div>
+  );
+};
+
+export default SharedNote;


### PR DESCRIPTION
## 📝 PR Description

- 공유된 노트 UI 구현 

---

## 🔍 Changes Made

- 노트 페이지 헤더의 공유 버튼을 누르면 공유된 노트로 이동됩니다.
- 공유된 노트 UI를 구현했습니다.

---

**설명**: 이 항목에서는 코드의 주요 변경 사항을 나열하여 리뷰어가 코드 수정의 목적을 쉽게 파악할 수 있도록 합니다.
변경된 주요 로직이나 UI 수정 사항이 있다면 구체적으로 설명합니다.

---

## 🔄 Extra Comments

- 공유 기능을 만든 것이 아닌 UI만 구현한 것이라 일단 공유 버튼을 누르면 이동하도록 구현했습니다.
- 아직 노트의 content에 들어가는 block의 생성, 삭제, 수정 등의 API가 연동이 안되어 blocks는 mock 데이터를 만들어 구현하였습니다.

---

**설명**: 이 PR과 관련된 추가적인 정보를 작성하여 리뷰어가 작업의 맥락을 이해하고, 리뷰에 필요한 내용을 쉽게 참고할 수
있도록 합니다. 이를 통해 PR의 내용을 명확히 전달할 수 있습니다.

---

## 📷 Demo


https://github.com/user-attachments/assets/cb74dd76-a953-472e-9b01-75148fcd60cf


---

**설명**: UI 변경 사항이 포함된 경우, 변경된 화면을 시각적으로 보여주기 위해 스크린샷이나 동영상을 첨부하면 도움이
됩니다. 리뷰어는 화면 변경 사항을 바로 확인할 수 있어 코드 리뷰가 더 효과적입니다.

---
