### PR TITLE
feat: block drag시 ghost 이미지 생성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -122,6 +122,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/src/app/(main)/note/[id]/_components/note-content/block-button.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block-button.tsx
@@ -10,6 +10,8 @@ interface IBlockButton {
   index: number;
   block: ITextBlock;
   blockList: ITextBlock[];
+  setDragBlockIndex: React.Dispatch<React.SetStateAction<number | null>>;
+  setIsTyping: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const blockBtnContainer = css({
@@ -37,11 +39,13 @@ const blockBtn = css({
   },
 });
 
-const BlockButton = ({ index, block, blockList }: IBlockButton) => {
+const BlockButton = ({ index, block, blockList, setDragBlockIndex, setIsTyping }: IBlockButton) => {
   const ghostRef = useRef<HTMLDivElement>(null);
 
   const handleDragStart = async (event: React.DragEvent<HTMLButtonElement>) => {
     if (ghostRef.current) {
+      setIsTyping(false);
+      setDragBlockIndex(index);
       const ghost = ghostRef.current;
 
       event.dataTransfer.setDragImage(ghost, 10, 10);

--- a/src/app/(main)/note/[id]/_components/note-content/block-button.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block-button.tsx
@@ -1,9 +1,16 @@
+import { useRef } from 'react';
 import { css } from '@/../styled-system/css';
 
 import PlusIcon from '@/icons/plus-icon';
 import GripVerticalIcon from '@/icons/grip-vertical-icon';
-import { useRef } from 'react';
+import { ITextBlock } from '@/types/block-type';
 import GhostBlock from './block/ghost-block';
+
+interface IBlockButton {
+  index: number;
+  block: ITextBlock;
+  blockList: ITextBlock[];
+}
 
 const blockBtnContainer = css({
   position: 'absolute',
@@ -30,12 +37,13 @@ const blockBtn = css({
   },
 });
 
-const BlockButton = ({ index, block, blockList }: any) => {
+const BlockButton = ({ index, block, blockList }: IBlockButton) => {
   const ghostRef = useRef<HTMLDivElement>(null);
 
-  const handleDragStart = async (event: React.DragEvent<HTMLDivElement>) => {
+  const handleDragStart = async (event: React.DragEvent<HTMLButtonElement>) => {
     if (ghostRef.current) {
       const ghost = ghostRef.current;
+
       event.dataTransfer.setDragImage(ghost, 10, 10);
     }
   };
@@ -46,9 +54,9 @@ const BlockButton = ({ index, block, blockList }: any) => {
       <div className={blockBtn}>
         <PlusIcon />
       </div>
-      <div className={blockBtn} draggable onDragStart={handleDragStart}>
+      <button type="button" className={blockBtn} draggable onDragStart={handleDragStart}>
         <GripVerticalIcon />
-      </div>
+      </button>
     </div>
   );
 };

--- a/src/app/(main)/note/[id]/_components/note-content/block-button.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block-button.tsx
@@ -123,9 +123,9 @@ const BlockButton = ({
   return (
     <div className={blockBtnContainer} ref={buttonRef}>
       <GhostBlock ghostRef={ghostRef} block={block} blockList={blockList} index={index} />
-      <div className={blockBtn} onClick={() => createBlock(index)}>
+      <button type="button" className={blockBtn} onClick={() => createBlock(index)}>
         <PlusIcon />
-      </div>
+      </button>
       <button type="button" className={blockBtn} onClick={handleOpen} draggable onDragStart={handleDragStart}>
         <GripVerticalIcon />
       </button>

--- a/src/app/(main)/note/[id]/_components/note-content/block-button.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block-button.tsx
@@ -2,6 +2,8 @@ import { css } from '@/../styled-system/css';
 
 import PlusIcon from '@/icons/plus-icon';
 import GripVerticalIcon from '@/icons/grip-vertical-icon';
+import { useRef } from 'react';
+import GhostBlock from './block/ghost-block';
 
 const blockBtnContainer = css({
   position: 'absolute',
@@ -28,13 +30,23 @@ const blockBtn = css({
   },
 });
 
-const BlockButton = () => {
+const BlockButton = ({ index, block, blockList }: any) => {
+  const ghostRef = useRef<HTMLDivElement>(null);
+
+  const handleDragStart = async (event: React.DragEvent<HTMLDivElement>) => {
+    if (ghostRef.current) {
+      const ghost = ghostRef.current;
+      event.dataTransfer.setDragImage(ghost, 10, 10);
+    }
+  };
+
   return (
     <div className={blockBtnContainer}>
+      <GhostBlock ghostRef={ghostRef} block={block} blockList={blockList} index={index} />
       <div className={blockBtn}>
         <PlusIcon />
       </div>
-      <div className={blockBtn}>
+      <div className={blockBtn} draggable onDragStart={handleDragStart}>
         <GripVerticalIcon />
       </div>
     </div>

--- a/src/app/(main)/note/[id]/_components/note-content/block/block.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block/block.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useEffect } from 'react';
+import { memo, useState, useRef, useEffect } from 'react';
 import { css } from '@/../styled-system/css';
 
 import { ITextBlock } from '@/types/block-type';
@@ -73,6 +73,8 @@ const Block = memo(
     const prevChildNodesLength = useRef(0);
     const prevClientY = useRef(0);
 
+    const [isDragOver, setIsDragOver] = useState(false);
+
     useEffect(() => {
       prevChildNodesLength.current = blockList[index].children.length;
     }, [blockList, index]);
@@ -84,6 +86,9 @@ const Block = memo(
         contentEditable
         suppressContentEditableWarning
         className={`parent ${blockDiv}`}
+        style={{
+          borderBottom: isDragOver ? '4px solid lightblue' : 'none',
+        }}
         onInput={event => {
           setIsTyping(true);
           handleInput(event, index, blockList, setBlockList, blockRef, prevChildNodesLength);
@@ -133,6 +138,27 @@ const Block = memo(
         onMouseLeave={() =>
           handleMouseLeave(index, isDragging, isUp, blockRef, selectionStartPosition, selectionEndPosition)
         }
+        onDragEnter={event => {
+          event.preventDefault();
+          setIsDragOver(true);
+        }}
+        onDragLeave={event => {
+          event.preventDefault();
+          const currentTarget = event.currentTarget as HTMLElement;
+          const related = event.relatedTarget as HTMLElement | null;
+
+          if (related && currentTarget.contains(related)) {
+            return;
+          }
+          setIsDragOver(false);
+        }}
+        onDragOver={event => {
+          event.preventDefault();
+        }}
+        onDrop={() => {
+          // TODO: 블록 순서 변경 로직
+          setIsDragOver(false);
+        }}
       >
         <BlockHTMLTag block={block} blockList={blockList} index={index} blockRef={blockRef}>
           {block.children.length === 1 && block.children[0].content === '' && <br />}

--- a/src/app/(main)/note/[id]/_components/note-content/block/block.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block/block.tsx
@@ -32,6 +32,7 @@ interface IBlockComponent {
   setIsSlashMenuOpen: React.Dispatch<React.SetStateAction<boolean[]>>;
   slashMenuPosition: { x: number; y: number };
   setSlashMenuPosition: React.Dispatch<React.SetStateAction<{ x: number; y: number }>>;
+  dragBlockIndex: number | null;
 }
 
 const blockDiv = css({
@@ -69,6 +70,7 @@ const Block = memo(
     setIsSlashMenuOpen,
     slashMenuPosition,
     setSlashMenuPosition,
+    dragBlockIndex,
   }: IBlockComponent) => {
     const prevChildNodesLength = useRef(0);
     const prevClientY = useRef(0);
@@ -139,10 +141,16 @@ const Block = memo(
           handleMouseLeave(index, isDragging, isUp, blockRef, selectionStartPosition, selectionEndPosition)
         }
         onDragEnter={event => {
+          if (dragBlockIndex === index) {
+            return;
+          }
           event.preventDefault();
           setIsDragOver(true);
         }}
         onDragLeave={event => {
+          if (dragBlockIndex === index) {
+            return;
+          }
           event.preventDefault();
           const currentTarget = event.currentTarget as HTMLElement;
           const related = event.relatedTarget as HTMLElement | null;

--- a/src/app/(main)/note/[id]/_components/note-content/block/ghost-block-html-tag.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block/ghost-block-html-tag.tsx
@@ -1,0 +1,76 @@
+import { css } from '@/../styled-system/css';
+
+import { ITextBlock } from '@/types/block-type';
+
+interface IGhostBlockHTMLTag {
+  block: ITextBlock;
+  blockList: ITextBlock[];
+  index: number;
+  children: React.ReactNode[];
+}
+
+const htmltag = css({
+  opacity: '0.4',
+});
+
+const GhostBlockHTMLTag = ({ block, blockList, index, children }: IGhostBlockHTMLTag) => {
+  if (block.type === 'default') {
+    return <p className={htmltag}>{children}</p>;
+  }
+
+  if (block.type === 'h1') {
+    return <h1 className={htmltag}>{children}</h1>;
+  }
+
+  if (block.type === 'h2') {
+    return <h2 className={htmltag}>{children}</h2>;
+  }
+
+  if (block.type === 'h3') {
+    return <h3 className={htmltag}>{children}</h3>;
+  }
+
+  if (block.type === 'ul') {
+    return (
+      <ul>
+        <li>
+          <p className={htmltag}>{children}</p>
+        </li>
+      </ul>
+    );
+  }
+
+  if (block.type === 'ol') {
+    let startNumber = 1;
+
+    blockList.forEach((item, idx) => {
+      if (idx >= index) return;
+
+      if (item.type === 'ol') {
+        startNumber += 1;
+      } else {
+        startNumber = 1;
+      }
+    });
+
+    return (
+      <ol start={startNumber}>
+        <li>
+          <p className={htmltag}>{children}</p>
+        </li>
+      </ol>
+    );
+  }
+
+  if (block.type === 'quote') {
+    return (
+      <blockquote>
+        <p className={htmltag}>{children}</p>
+      </blockquote>
+    );
+  }
+
+  return null;
+};
+
+export default GhostBlockHTMLTag;

--- a/src/app/(main)/note/[id]/_components/note-content/block/ghost-block.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block/ghost-block.tsx
@@ -1,0 +1,45 @@
+import { css } from '@/../styled-system/css';
+
+import { ITextBlock } from '@/types/block-type';
+import GhostBlockHTMLTag from './ghost-block-html-tag';
+
+interface IGhostBlock {
+  ghostRef: React.RefObject<HTMLDivElement | null>;
+  block: ITextBlock;
+  blockList: ITextBlock[];
+  index: number;
+}
+
+const container = css({
+  position: 'absolute',
+  top: '-9999px',
+  left: '-9999px',
+  padding: '8px 16px',
+  borderRadius: '4px',
+});
+
+const GhostBlock = ({ ghostRef, block, blockList, index }: IGhostBlock) => {
+  return (
+    <div ref={ghostRef} className={container}>
+      <GhostBlockHTMLTag block={block} blockList={blockList} index={index}>
+        {block.children.map((child, idx) => {
+          if (child.type === 'br') {
+            return <br key={idx} />;
+          }
+
+          if (child.type === 'text') {
+            return child.content;
+          }
+
+          return (
+            <span key={idx} style={child.style}>
+              {child.content}
+            </span>
+          );
+        })}
+      </GhostBlockHTMLTag>
+    </div>
+  );
+};
+
+export default GhostBlock;

--- a/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
@@ -228,7 +228,8 @@ const NoteContent = () => {
   const handleFakeBoxMouseEnter = (index: number) => {
     if (isTyping) {
       const { startOffset, startContainer } = getSelectionInfo(0) || {};
-      const parent = blockRef.current[index];
+      const blockIndex = blockRef.current.findIndex(blockEl => blockEl && blockEl.contains(startContainer as Node));
+      const parent = blockRef.current[blockIndex];
       const childNodes = Array.from(parent?.childNodes as NodeListOf<HTMLElement>);
       const currentChildNodeIndex =
         childNodes.indexOf(startContainer as HTMLElement) === -1 && startContainer?.nodeType === Node.TEXT_NODE
@@ -240,13 +241,12 @@ const NoteContent = () => {
 
       setTimeout(() => {
         const range = document.createRange();
-        const targetNode = blockRef.current[index]?.childNodes[currentChildNodeIndex];
+        const targetNode = blockRef.current[blockIndex]?.childNodes[currentChildNodeIndex];
         range.setStart(targetNode as Node, startOffset || 0);
-
         const selection = window.getSelection();
         selection?.removeAllRanges();
         selection?.addRange(range);
-      }, 0);
+      }, 100);
     }
 
     if (!isDragging) return;

--- a/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
@@ -324,7 +324,7 @@ const NoteContent = () => {
                   blockButtonRef.current[index] = element;
                 }}
               >
-                <BlockButton />
+                <BlockButton index={index} block={block} blockList={blockList} />
               </div>
             </div>
             <Block

--- a/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { css } from '@/../styled-system/css';
 
+import getSelectionInfo from '@/utils/getSelectionInfo';
 import { ITextBlock } from '@/types/block-type';
 import fillHTMLElementBackgroundImage from '@/utils/fillHTMLElementBackgroundImage';
 import ISelectionPosition from '@/types/selection-position';
@@ -53,6 +54,7 @@ const NoteContent = () => {
       ],
     },
   ]);
+
   const [key, setKey] = useState(Date.now());
   const [isTyping, setIsTyping] = useState(false);
 
@@ -224,6 +226,29 @@ const NoteContent = () => {
   };
 
   const handleFakeBoxMouseEnter = (index: number) => {
+    if (isTyping) {
+      const { startOffset, startContainer } = getSelectionInfo(0) || {};
+      const parent = blockRef.current[index];
+      const childNodes = Array.from(parent?.childNodes as NodeListOf<HTMLElement>);
+      const currentChildNodeIndex =
+        childNodes.indexOf(startContainer as HTMLElement) === -1 && startContainer?.nodeType === Node.TEXT_NODE
+          ? childNodes.indexOf(startContainer.parentNode as HTMLElement)
+          : childNodes.indexOf(startContainer as HTMLElement);
+
+      setIsTyping(false);
+      setKey(Math.random());
+
+      setTimeout(() => {
+        const range = document.createRange();
+        const targetNode = blockRef.current[index]?.childNodes[currentChildNodeIndex];
+        range.setStart(targetNode as Node, startOffset || 0);
+
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      }, 0);
+    }
+
     if (!isDragging) return;
     const parent = blockRef.current[index];
     const childNodes = Array.from(parent?.childNodes as NodeListOf<HTMLElement>);

--- a/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
@@ -305,21 +305,21 @@ const NoteContent = () => {
             tabIndex={0}
             key={block.id}
             className={blockContainer}
-            onMouseEnter={() => handleMouseEnter(index)}
-            onMouseLeave={() => handleMouseLeave(index)}
-            onKeyDown={() => handleMouseLeave(index)}
-            onMouseMove={() => handleMouseEnter(index)}
+            // onMouseEnter={() => handleMouseEnter(index)}
+            // onMouseLeave={() => handleMouseLeave(index)}
+            // onKeyDown={() => handleMouseLeave(index)}
+            // onMouseMove={() => handleMouseEnter(index)}
           >
             <div
               className={fakeBox}
               ref={element => {
                 fakeBoxRef.current[index] = element;
               }}
-              onMouseEnter={() => handleFakeBoxMouseEnter(index)}
-              onMouseLeave={() => handleFakeBoxMouseLeave(index)}
+              // onMouseEnter={() => handleFakeBoxMouseEnter(index)}
+              // onMouseLeave={() => handleFakeBoxMouseLeave(index)}
             >
               <div
-                className={css({ display: 'none' })}
+                // className={css({ display: 'none' })}
                 ref={element => {
                   blockButtonRef.current[index] = element;
                 }}

--- a/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
@@ -37,6 +37,7 @@ const NoteContent = () => {
   const blockRef = useRef<(HTMLDivElement | null)[]>([]);
   const noteRef = useRef<HTMLDivElement | null>(null);
   const selectionMenuRef = useRef<HTMLDivElement | null>(null);
+  const [dragBlockIndex, setDragBlockIndex] = useState<number | null>(null);
 
   const [blockList, setBlockList] = useState<ITextBlock[]>([
     {
@@ -305,26 +306,32 @@ const NoteContent = () => {
             tabIndex={0}
             key={block.id}
             className={blockContainer}
-            // onMouseEnter={() => handleMouseEnter(index)}
-            // onMouseLeave={() => handleMouseLeave(index)}
-            // onKeyDown={() => handleMouseLeave(index)}
-            // onMouseMove={() => handleMouseEnter(index)}
+            onMouseEnter={() => handleMouseEnter(index)}
+            onMouseLeave={() => handleMouseLeave(index)}
+            onKeyDown={() => handleMouseLeave(index)}
+            onMouseMove={() => handleMouseEnter(index)}
           >
             <div
               className={fakeBox}
               ref={element => {
                 fakeBoxRef.current[index] = element;
               }}
-              // onMouseEnter={() => handleFakeBoxMouseEnter(index)}
-              // onMouseLeave={() => handleFakeBoxMouseLeave(index)}
+              onMouseEnter={() => handleFakeBoxMouseEnter(index)}
+              onMouseLeave={() => handleFakeBoxMouseLeave(index)}
             >
               <div
-                // className={css({ display: 'none' })}
+                className={css({ display: 'none' })}
                 ref={element => {
                   blockButtonRef.current[index] = element;
                 }}
               >
-                <BlockButton index={index} block={block} blockList={blockList} />
+                <BlockButton
+                  index={index}
+                  block={block}
+                  blockList={blockList}
+                  setDragBlockIndex={setDragBlockIndex}
+                  setIsTyping={setIsTyping}
+                />
               </div>
             </div>
             <Block
@@ -348,6 +355,7 @@ const NoteContent = () => {
               setIsSlashMenuOpen={setIsSlashMenuOpen}
               slashMenuPosition={slashMenuPosition}
               setSlashMenuPosition={setSlashMenuPosition}
+              dragBlockIndex={dragBlockIndex}
             />
           </div>
         ))}


### PR DESCRIPTION
## 📝 PR Description

- block drag시 ghost 이미지 생성

---

## 🔍 Changes Made

- blcok button을 잡은채로 드래그 하면 드래그한 블록과 같은 형태의 고스트 블록이 커서를 따라갑니다.
- 블록을 드래그한 채로 자신이 아닌 다른 블록위에 커서를 올리면 해당 블록에 밑줄이 생깁니다.

---

**설명**: 이 항목에서는 코드의 주요 변경 사항을 나열하여 리뷰어가 코드 수정의 목적을 쉽게 파악할 수 있도록 합니다.
변경된 주요 로직이나 UI 수정 사항이 있다면 구체적으로 설명합니다.

---

## 🔄 Extra Comments

- 블록을 드래그 하기 전 setKey를 통해 컴포넌트를 초기화하지 않으면 에러 발생
- 블록 버튼을 클릭하는 순간 setKey를 하게 되면 드래그는 되지만, 블록 버튼 클릭시 드롭다운이 나오는 기능이 작동을 안함
- 이를 해결하기 위해 블록 버튼을 감싸고 있는 fake box에 마우스를 올리자마자 setKey로 컴포넌트 초기화
- 컴포넌트 초기화 후 focus 가 사라져 원래 커서 위치에 포커스를 유지하는 로직 추가

---

**설명**: 이 PR과 관련된 추가적인 정보를 작성하여 리뷰어가 작업의 맥락을 이해하고, 리뷰에 필요한 내용을 쉽게 참고할 수
있도록 합니다. 이를 통해 PR의 내용을 명확히 전달할 수 있습니다.

---

## 📷 Demo


https://github.com/user-attachments/assets/7e16b943-88f9-460f-93c2-62ea341524a4


---

**설명**: UI 변경 사항이 포함된 경우, 변경된 화면을 시각적으로 보여주기 위해 스크린샷이나 동영상을 첨부하면 도움이
됩니다. 리뷰어는 화면 변경 사항을 바로 확인할 수 있어 코드 리뷰가 더 효과적입니다.

---
