### PR TITLE
feat: 블록 순서 맨 앞으로 이동

### DIFF
--- a/src/apis/note.ts
+++ b/src/apis/note.ts
@@ -15,7 +15,7 @@ export const getNoteList = async () => {
   const instance = await getInstance();
   const response = await instance.get(`/notes`);
 
-  return response.data;
+  return response.data.notes;
 };
 
 export const editNoteIcon = async (noteId: string, selectedIcon: string | null) => {

--- a/src/app/(main)/_components/chart/chart.tsx
+++ b/src/app/(main)/_components/chart/chart.tsx
@@ -73,7 +73,7 @@ const LineChart = ({ width: totalWidth, height: totalHeight, margin = defaultMar
     name: 'WorkSpace',
     id: '',
     colorKey: 'LINE_ONE',
-    children: convertNoteListToTree(noteList.notes),
+    children: convertNoteListToTree(noteList),
   };
 
   const STORAGE_KEY = 'tree-node-colors';

--- a/src/app/(main)/_components/sidebar/finder/finder-card.tsx
+++ b/src/app/(main)/_components/sidebar/finder/finder-card.tsx
@@ -93,8 +93,8 @@ const FinderCard = () => {
         )}
       </div>
       <div className={noteContainer}>
-        {noteList?.notes.length ? (
-          noteList.notes.map((note: INotes) => (
+        {noteList?.length ? (
+          noteList.map((note: INotes) => (
             <PageItem
               key={note.id}
               note={note}

--- a/src/app/(main)/_components/sidebar/finder/page-item.tsx
+++ b/src/app/(main)/_components/sidebar/finder/page-item.tsx
@@ -141,12 +141,12 @@ const NoteItem = ({ note, depth, openedDropdownnoteId, setOpenedDropdownnoteId }
     setOpenedDropdownnoteId(null);
   };
 
-  const findParentId = (nodeList: INotes[], targetId: string, parentId: string | null = null): string | null => {
-    const match = nodeList.find(node => {
-      if (node.id === targetId) return true;
+  const findParentId = (notes: INotes[], targetId: string, parentId: string | null = null): string | null => {
+    const match = notes.find(item => {
+      if (item.id === targetId) return true;
 
-      if (node.children?.length) {
-        const found = findParentId(node.children, targetId, node.id);
+      if (item.children?.length) {
+        const found = findParentId(item.children, targetId, item.id);
         if (found) {
           parentId = found;
           return true;
@@ -163,7 +163,7 @@ const NoteItem = ({ note, depth, openedDropdownnoteId, setOpenedDropdownnoteId }
     try {
       await deleteNote(note.id);
       await mutate('noteList', getNoteList, false);
-      const parentId = findParentId(noteList.notes, note.id);
+      const parentId = findParentId(noteList, note.id);
 
       if (parentId) {
         router.push(`/note/${parentId}`);

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -15,22 +15,18 @@ const MainLayout = async ({ children, modal }: Readonly<{ children: React.ReactN
     redirect('/login');
   }
 
-  const { data: noteList } = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/notes`, {
+  const { data } = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/notes`, {
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
     },
   });
 
-  console.log(noteList);
-
-  // const noteList = noteResponse.data;
-
   return (
     <SWRConfig
       value={{
         fallback: {
-          [`noteList`]: noteList,
+          [`noteList`]: data.notes,
         },
       }}
     >

--- a/src/app/(main)/note/[id]/_components/header.tsx
+++ b/src/app/(main)/note/[id]/_components/header.tsx
@@ -73,12 +73,12 @@ const Header = () => {
     router.push(`/note/share/${noteId}`);
   };
 
-  const findParentId = (nodeList: INotes[], targetId: string, parentId: string | null = null): string | null => {
-    const match = nodeList.find(node => {
-      if (node.id === targetId) return true;
+  const findParentId = (notes: INotes[], targetId: string, parentId: string | null = null): string | null => {
+    const match = notes.find(note => {
+      if (note.id === targetId) return true;
 
-      if (node.children?.length) {
-        const found = findParentId(node.children, targetId, node.id);
+      if (note.children?.length) {
+        const found = findParentId(note.children, targetId, note.id);
         if (found) {
           parentId = found;
           return true;
@@ -95,7 +95,7 @@ const Header = () => {
     try {
       await deleteNote(noteId);
       await mutate('noteList', getNoteList, false);
-      const parentId = findParentId(noteList.notes, noteId);
+      const parentId = findParentId(noteList, noteId);
       if (parentId) {
         router.push(`/note/${parentId}`);
       } else {
@@ -108,7 +108,8 @@ const Header = () => {
   };
 
   const handleBackButton = () => {
-    const parentId = findParentId(noteList.node, noteId);
+    console.log(noteList);
+    const parentId = findParentId(noteList, noteId);
     if (parentId) {
       router.push(`/note/${parentId}`);
     } else {

--- a/src/app/(main)/note/[id]/_components/note-header/note-header.tsx
+++ b/src/app/(main)/note/[id]/_components/note-header/note-header.tsx
@@ -16,7 +16,7 @@ import CoverDropdown from './cover-dropdown/dropdown';
 const headerConatiner = css({
   width: '44.5rem',
   position: 'relative',
-  zIndex: 2,
+  zIndex: '20',
 });
 
 const IconContainer = css({
@@ -156,8 +156,8 @@ const NoteHeader = () => {
           handleSelectCover={handleSelectCover}
         />
         <Title noteId={noteId} />
+        <Tag noteId={noteId} />
       </div>
-      <Tag noteId={noteId} />
     </>
   );
 };


### PR DESCRIPTION
## 📝 PR Description

- 블록 순서 맨 앞으로 이동

---

## 🔍 Changes Made

- 첫 번째 블록 위에 div를 두고 그 위로 드래그엔 드롭 시 맨 앞으로 드래그 한 블록의 순서 이동
- 노트 헤더에 뒤로가기 버튼 에러 해결
  - 해결 과정에서 noteList 불러오는 API 구조 수정

---

**설명**: 이 항목에서는 코드의 주요 변경 사항을 나열하여 리뷰어가 코드 수정의 목적을 쉽게 파악할 수 있도록 합니다.
변경된 주요 로직이나 UI 수정 사항이 있다면 구체적으로 설명합니다.

---

## 📷 Demo


https://github.com/user-attachments/assets/b909da99-5694-4b5e-b5cb-bd2c3a262199


---

**설명**: UI 변경 사항이 포함된 경우, 변경된 화면을 시각적으로 보여주기 위해 스크린샷이나 동영상을 첨부하면 도움이
됩니다. 리뷰어는 화면 변경 사항을 바로 확인할 수 있어 코드 리뷰가 더 효과적입니다.

---
