### PR TITLE
Fix : blockButtonModal이 중복으로 띄워지던 오류 수정 및 전체선택 기본 셀렉션 막기

### DIFF
--- a/src/app/(main)/note/[id]/_components/note-content/block-button.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block-button.tsx
@@ -145,7 +145,7 @@ const BlockButton = ({
     setIsblockButtonModalOpen(true);
     setMenuState(prev => ({
       ...prev,
-      slashMenuOpenIndex: index,
+      blockButtonModalIndex: index,
     }));
 
     OpenBlockMenu();
@@ -184,7 +184,7 @@ const BlockButton = ({
       <button type="button" className={blockBtn} onClick={handleOpen} draggable onDragStart={handleDragStart}>
         <GripVerticalIcon />
       </button>
-      {menuState.slashMenuOpenIndex === index && (
+      {menuState.blockButtonModalIndex === index && (
         <DropDown handleClose={handleClose}>
           <DropDown.Menu isOpen={isblockButtonModalOpen} top={dropdownPosition.top} left={dropdownPosition.left}>
             <DropDown.Item onClick={handleChange}>

--- a/src/app/(main)/note/[id]/_components/note-content/block-button.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/block-button.tsx
@@ -70,7 +70,6 @@ const BlockButton = ({
   setMenuState,
 }: IBlockButton) => {
   const [isblockButtonModalOpen, setIsblockButtonModalOpen] = useState(false);
-
   const buttonRef = useRef<HTMLDivElement>(null);
   const [dropdownPosition, setDropdownPosition] = useState({ top: 0, left: 0 });
   const [openedBySlashKey, setOpenedBySlashKey] = useState(true);
@@ -144,6 +143,11 @@ const BlockButton = ({
       });
     }
     setIsblockButtonModalOpen(true);
+    setMenuState(prev => ({
+      ...prev,
+      slashMenuOpenIndex: index,
+    }));
+
     OpenBlockMenu();
   };
 
@@ -180,20 +184,22 @@ const BlockButton = ({
       <button type="button" className={blockBtn} onClick={handleOpen} draggable onDragStart={handleDragStart}>
         <GripVerticalIcon />
       </button>
-      <DropDown handleClose={handleClose}>
-        <DropDown.Menu isOpen={isblockButtonModalOpen} top={dropdownPosition.top} left={dropdownPosition.left}>
-          <DropDown.Item onClick={handleChange}>
-            <ArrowReapeatIcon width="16px" height="16px" />
-            전환
-          </DropDown.Item>
-          <DropDown.Item onClick={handleDelete}>
-            <div className={deleteBtn}>
-              <TrashIcon />
-              삭제하기
-            </div>
-          </DropDown.Item>
-        </DropDown.Menu>
-      </DropDown>
+      {menuState.slashMenuOpenIndex === index && (
+        <DropDown handleClose={handleClose}>
+          <DropDown.Menu isOpen={isblockButtonModalOpen} top={dropdownPosition.top} left={dropdownPosition.left}>
+            <DropDown.Item onClick={handleChange}>
+              <ArrowReapeatIcon width="16px" height="16px" />
+              전환
+            </DropDown.Item>
+            <DropDown.Item onClick={handleDelete}>
+              <div className={deleteBtn}>
+                <TrashIcon />
+                삭제하기
+              </div>
+            </DropDown.Item>
+          </DropDown.Menu>
+        </DropDown>
+      )}
       {menuState.isSlashMenuOpen && menuState.slashMenuOpenIndex === index && (
         <SlashMenu
           index={index}

--- a/src/app/(main)/note/[id]/_components/note-content/block/handler/handleKeyDown.ts
+++ b/src/app/(main)/note/[id]/_components/note-content/block/handler/handleKeyDown.ts
@@ -660,7 +660,6 @@ const handleKeyDown = async (
   selection: ISelectionPosition,
   noteId: string,
 ) => {
-  console.log(event.key);
   // selection 없을때
   if (!menuState.isSelectionMenuOpen) {
     if (

--- a/src/app/(main)/note/[id]/_components/note-content/block/handler/handleKeyDown.ts
+++ b/src/app/(main)/note/[id]/_components/note-content/block/handler/handleKeyDown.ts
@@ -660,6 +660,7 @@ const handleKeyDown = async (
   selection: ISelectionPosition,
   noteId: string,
 ) => {
+  console.log(event.key);
   // selection 없을때
   if (!menuState.isSelectionMenuOpen) {
     if (
@@ -668,6 +669,12 @@ const handleKeyDown = async (
     ) {
       event.preventDefault();
     }
+
+    // ctrl + A 텍스트 전체 선택 기본 셀렉션 막기
+    if (event.ctrlKey && (event.key === 'a' || event.key === 'A')) {
+      event.preventDefault();
+    }
+
     // enter 클릭
     if (event.key === keyName.enter && !event.shiftKey) {
       event.preventDefault();

--- a/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
@@ -85,12 +85,13 @@ const NoteContent = () => {
     isSlashMenuOpen: false,
     slashMenuOpenIndex: null,
     isSelectionMenuOpen: false,
+    blockButtonModalIndex: null,
     slashMenuPosition: { x: 0, y: 0 },
     selectionMenuPosition: { x: 0, y: 0 },
   });
 
   const [isBlockMenuOpen, setIsBlockMenuOpen] = useState(false);
-  const [sidebarWidth, setSidebarWidth] = useState<number | null>(null);
+  const [sidebarWidth, setSidebarWidth] = useState<number>(0);
 
   useEffect(() => {
     const sidebarEl = document.getElementById('sidebar');

--- a/src/types/menu-type.ts
+++ b/src/types/menu-type.ts
@@ -2,6 +2,7 @@ interface IMenuState {
   isSlashMenuOpen: boolean;
   slashMenuOpenIndex: number | null;
   isSelectionMenuOpen: boolean;
+  blockButtonModalIndex: number | null;
   slashMenuPosition: { x: number; y: number };
   selectionMenuPosition: { x: number; y: number };
 }


### PR DESCRIPTION
## 📝 PR Description

- blockButtonModal이 중복으로 띄워지던 오류 수정 및 전체선택 기본 셀렉션 막기

---

## 🔍 Changes Made

- blockButtonModal 이 중복으로 띄워지던 오류 해결
- ctrl + A 커맨드 막기

---

## 🔄 Extra Comments

- menuState에 blockButtonModalIndex을 넣어 통일성을 유지하고, 모달이 중복으로 띄워지던 오류 해결

---