### PR TITLE
Fix : Focus 로직 수정 및 shift + enter 로직 수정

### DIFF
--- a/src/app/(main)/note/[id]/_components/header.tsx
+++ b/src/app/(main)/note/[id]/_components/header.tsx
@@ -108,7 +108,6 @@ const Header = () => {
   };
 
   const handleBackButton = () => {
-    console.log(noteList);
     const parentId = findParentId(noteList, noteId);
     if (parentId) {
       router.push(`/note/${parentId}`);

--- a/src/app/(main)/note/[id]/_components/note-content/block/handler/handleKeyDown.ts
+++ b/src/app/(main)/note/[id]/_components/note-content/block/handler/handleKeyDown.ts
@@ -260,154 +260,155 @@ const splitBlock = async (
   focusBlock(index + 1, blockRef, updatedBlockList);
 };
 
-const splitLine = async (
-  index: number,
-  blockList: ITextBlock[],
-  blockRef: React.RefObject<(HTMLDivElement | null)[]>,
-  noteId: string,
-) => {
-  const { startOffset, startContainer } = getSelectionInfo(0) || {};
-  if (startOffset === undefined || startOffset === null || !startContainer) return;
+// note : shift + enter 미완 로직
+// const splitLine = async (
+//   index: number,
+//   blockList: ITextBlock[],
+//   blockRef: React.RefObject<(HTMLDivElement | null)[]>,
+//   noteId: string,
+// ) => {
+//   const { startOffset, startContainer } = getSelectionInfo(0) || {};
+//   if (startOffset === undefined || startOffset === null || !startContainer) return;
 
-  const parent = blockRef.current[index];
-  const childNodes = Array.from(parent?.childNodes as NodeListOf<HTMLElement>);
-  const currentChildNodeIndex =
-    childNodes.indexOf(startContainer as HTMLElement) === -1 && startContainer?.nodeType === Node.TEXT_NODE
-      ? childNodes.indexOf(startContainer.parentNode as HTMLElement)
-      : childNodes.indexOf(startContainer as HTMLElement);
-  const newChildren = [...blockList[index].nodes];
+//   const parent = blockRef.current[index];
+//   const childNodes = Array.from(parent?.childNodes as NodeListOf<HTMLElement>);
+//   const currentChildNodeIndex =
+//     childNodes.indexOf(startContainer as HTMLElement) === -1 && startContainer?.nodeType === Node.TEXT_NODE
+//       ? childNodes.indexOf(startContainer.parentNode as HTMLElement)
+//       : childNodes.indexOf(startContainer as HTMLElement);
+//   const newChildren = [...blockList[index].nodes];
 
-  if (startContainer.nodeType === Node.TEXT_NODE) {
-    const textBefore = startContainer.textContent?.substring(0, startOffset);
-    const textAfter = startContainer.textContent?.substring(startOffset);
+//   if (startContainer.nodeType === Node.TEXT_NODE) {
+//     const textBefore = startContainer.textContent?.substring(0, startOffset);
+//     const textAfter = startContainer.textContent?.substring(startOffset);
 
-    const parentNode = startContainer.parentNode as HTMLElement;
-    const isSpan = parentNode?.tagName === 'SPAN';
+//     const parentNode = startContainer.parentNode as HTMLElement;
+//     const isSpan = parentNode?.tagName === 'SPAN';
 
-    // 줄 바꿈이 반영된 children 배열 생성
-    const updatedChildren = [
-      ...newChildren.slice(0, currentChildNodeIndex),
-      textBefore && {
-        type: !isSpan ? 'text' : 'span',
-        style: isSpan
-          ? {
-              fontStyle: parentNode?.style.fontStyle,
-              fontWeight: parentNode?.style.fontWeight,
-              color: parentNode?.style.color,
-              backgroundColor: parentNode?.style.backgroundColor,
-              width: 'auto',
-              height: 'auto',
-            }
-          : null,
-        content: textBefore || '',
-      },
-      textBefore && textAfter
-        ? {
-            type: 'br' as 'br',
-          }
-        : null,
-      textAfter && {
-        type: !isSpan ? 'text' : 'span',
-        style: isSpan
-          ? {
-              fontStyle: parentNode?.style.fontStyle,
-              fontWeight: parentNode?.style.fontWeight,
-              color: parentNode?.style.color,
-              backgroundColor: parentNode?.style.backgroundColor,
-              width: 'auto',
-              height: 'auto',
-            }
-          : null,
-        content: textAfter || '',
-      },
-      ...newChildren.slice(currentChildNodeIndex + 1),
-    ]
-      .map(child => {
-        if (child === '') {
-          return {
-            type: 'br' as 'br',
-          };
-        }
+//     // 줄 바꿈이 반영된 children 배열 생성
+//     const updatedChildren = [
+//       ...newChildren.slice(0, currentChildNodeIndex),
+//       textBefore && {
+//         type: !isSpan ? 'text' : 'span',
+//         style: isSpan
+//           ? {
+//               fontStyle: parentNode?.style.fontStyle,
+//               fontWeight: parentNode?.style.fontWeight,
+//               color: parentNode?.style.color,
+//               backgroundColor: parentNode?.style.backgroundColor,
+//               width: 'auto',
+//               height: 'auto',
+//             }
+//           : null,
+//         content: textBefore || '',
+//       },
+//       textBefore && textAfter
+//         ? {
+//             type: 'br' as 'br',
+//           }
+//         : null,
+//       textAfter && {
+//         type: !isSpan ? 'text' : 'span',
+//         style: isSpan
+//           ? {
+//               fontStyle: parentNode?.style.fontStyle,
+//               fontWeight: parentNode?.style.fontWeight,
+//               color: parentNode?.style.color,
+//               backgroundColor: parentNode?.style.backgroundColor,
+//               width: 'auto',
+//               height: 'auto',
+//             }
+//           : null,
+//         content: textAfter || '',
+//       },
+//       ...newChildren.slice(currentChildNodeIndex + 1),
+//     ]
+//       .map(child => {
+//         if (child === '') {
+//           return {
+//             type: 'br' as 'br',
+//           };
+//         }
 
-        return child;
-      })
-      .filter(child => child !== null);
+//         return child;
+//       })
+//       .filter(child => child !== null);
 
-    // 줄의 맨 마지막에서 줄바꿈을 할 떄는 <br> 태그가 하나 더 추가 되야함 ex) 줄바꿈 후 두 번째 줄이 빈 문자열일 때: ""<br><br>
-    if (
-      updatedChildren[updatedChildren.length - 1]?.type === 'br' &&
-      updatedChildren[updatedChildren.length - 2]?.type !== 'br'
-    ) {
-      updatedChildren.push({
-        type: 'br' as 'br',
-      });
-    }
+//     // 줄의 맨 마지막에서 줄바꿈을 할 떄는 <br> 태그가 하나 더 추가 되야함 ex) 줄바꿈 후 두 번째 줄이 빈 문자열일 때: ""<br><br>
+//     if (
+//       updatedChildren[updatedChildren.length - 1]?.type === 'br' &&
+//       updatedChildren[updatedChildren.length - 2]?.type !== 'br'
+//     ) {
+//       updatedChildren.push({
+//         type: 'br' as 'br',
+//       });
+//     }
 
-    const updatedBlockList = [...blockList];
-    updatedBlockList[index] = {
-      ...updatedBlockList[index],
-      nodes: updatedChildren as ITextBlock['nodes'],
-    };
+//     const updatedBlockList = [...blockList];
+//     updatedBlockList[index] = {
+//       ...updatedBlockList[index],
+//       nodes: updatedChildren as ITextBlock['nodes'],
+//     };
 
-    // 현재 블록 업데이트
-    await updateBlockNodes(blockList[index].id, updatedBlockList[index].nodes);
-  } else if ((startContainer as HTMLElement).tagName === 'BR') {
-    // 현재 커서 위치 한 곳이 빈 문자열일 때 → 중복 줄바꿈 로직
-    // 직접 focus를 줄 때는 startContainer가 <br>로 잡힘
-    const updatedBlockList = [...blockList];
-    if (updatedBlockList[index].nodes.length === 1 && updatedBlockList[index].nodes[0].content === '') {
-      updatedBlockList[index].nodes[0] = {
-        type: 'br',
-      };
-    }
-    updatedBlockList[index].nodes.splice(currentChildNodeIndex, 0, {
-      type: 'br',
-    });
+//     // 현재 블록 업데이트
+//     await updateBlockNodes(blockList[index].id, updatedBlockList[index].nodes);
+//   } else if ((startContainer as HTMLElement).tagName === 'BR') {
+//     // 현재 커서 위치 한 곳이 빈 문자열일 때 → 중복 줄바꿈 로직
+//     // 직접 focus를 줄 때는 startContainer가 <br>로 잡힘
+//     const updatedBlockList = [...blockList];
+//     if (updatedBlockList[index].nodes.length === 1 && updatedBlockList[index].nodes[0].content === '') {
+//       updatedBlockList[index].nodes[0] = {
+//         type: 'br',
+//       };
+//     }
+//     updatedBlockList[index].nodes.splice(currentChildNodeIndex, 0, {
+//       type: 'br',
+//     });
 
-    // 현재 블록 업데이트
-    await updateBlockNodes(blockList[index].id, updatedBlockList[index].nodes);
-  } else {
-    // 현재 커서 위치 한 곳이 빈 문자열일 때 → 중복 줄바꿈 로직
-    // 직접 focus를 주지 않을 때는 startContainer가 부모로 잡혀 text node와 br이 아님
-    const updatedBlockList = [...blockList];
-    if (updatedBlockList[index].nodes.length === 1 && updatedBlockList[index].nodes[0].content === '') {
-      updatedBlockList[index].nodes[0] = {
-        type: 'br',
-      };
-    }
-    updatedBlockList[index].nodes.splice(startOffset, 0, {
-      type: 'br',
-    });
+//     // 현재 블록 업데이트
+//     await updateBlockNodes(blockList[index].id, updatedBlockList[index].nodes);
+//   } else {
+//     // 현재 커서 위치 한 곳이 빈 문자열일 때 → 중복 줄바꿈 로직
+//     // 직접 focus를 주지 않을 때는 startContainer가 부모로 잡혀 text node와 br이 아님
+//     const updatedBlockList = [...blockList];
+//     if (updatedBlockList[index].nodes.length === 1 && updatedBlockList[index].nodes[0].content === '') {
+//       updatedBlockList[index].nodes[0] = {
+//         type: 'br',
+//       };
+//     }
+//     updatedBlockList[index].nodes.splice(startOffset, 0, {
+//       type: 'br',
+//     });
 
-    // 현재 블록 업데이트
-    await updateBlockNodes(blockList[index].id, updatedBlockList[index].nodes);
-  }
+//     // 현재 블록 업데이트
+//     await updateBlockNodes(blockList[index].id, updatedBlockList[index].nodes);
+//   }
 
-  await mutate(`blockList-${noteId}`, getBlockList(noteId), false);
+//   await mutate(`blockList-${noteId}`, getBlockList(noteId), false);
 
-  // 줄 바꿈 후 focus를 바뀐줄 맨 앞에 주는 로직
-  setTimeout(() => {
-    const newChildNodes = Array.from(blockRef.current[index]?.childNodes as NodeListOf<HTMLElement>);
-    const range = document.createRange();
+//   // 줄 바꿈 후 focus를 바뀐줄 맨 앞에 주는 로직
+//   setTimeout(() => {
+//     const newChildNodes = Array.from(blockRef.current[index]?.childNodes as NodeListOf<HTMLElement>);
+//     const range = document.createRange();
 
-    if (
-      (currentChildNodeIndex === 0 && startOffset === 0) ||
-      (childNodes[currentChildNodeIndex - 1]?.nodeName === 'BR' && startOffset === 0)
-    ) {
-      // 줄의 맨 앞에 커서를 두고 줄바꿈 했을 때
-      range.setStart(newChildNodes[currentChildNodeIndex + 1], 0);
-    } else if (currentChildNodeIndex === -1) {
-      // 직접 focus를 주지 않은 상태에서 빈 줄에서 줄바꿈 했을 때
-      range.setStart(newChildNodes[startOffset + 1], 0);
-    } else {
-      range.setStart(newChildNodes[startOffset === 0 ? currentChildNodeIndex + 1 : currentChildNodeIndex + 2], 0);
-    }
+//     if (
+//       (currentChildNodeIndex === 0 && startOffset === 0) ||
+//       (childNodes[currentChildNodeIndex - 1]?.nodeName === 'BR' && startOffset === 0)
+//     ) {
+//       // 줄의 맨 앞에 커서를 두고 줄바꿈 했을 때
+//       range.setStart(newChildNodes[currentChildNodeIndex + 1], 0);
+//     } else if (currentChildNodeIndex === -1) {
+//       // 직접 focus를 주지 않은 상태에서 빈 줄에서 줄바꿈 했을 때
+//       range.setStart(newChildNodes[startOffset + 1], 0);
+//     } else {
+//       range.setStart(newChildNodes[startOffset === 0 ? currentChildNodeIndex + 1 : currentChildNodeIndex + 2], 0);
+//     }
 
-    const selection = window.getSelection();
-    selection?.removeAllRanges();
-    selection?.addRange(range);
-  }, 0);
-};
+//     const selection = window.getSelection();
+//     selection?.removeAllRanges();
+//     selection?.addRange(range);
+//   }, 0);
+// };
 
 const mergeBlock = async (
   index: number,
@@ -668,8 +669,8 @@ const handleKeyDown = async (
     ) {
       event.preventDefault();
     }
-    // enter 클릭
-    if (event.key === keyName.enter && !event.shiftKey) {
+    // enter 클릭 || shift + enter 클릭
+    if ((event.key === keyName.enter && !event.shiftKey) || (event.key === keyName.enter && event.shiftKey)) {
       event.preventDefault();
       if (event.nativeEvent.isComposing) {
         return;
@@ -677,14 +678,6 @@ const handleKeyDown = async (
       setIsTyping(false);
       setKey(Math.random());
       splitBlock(index, blockList, blockRef, noteId);
-    }
-
-    // shift + enter 클릭
-    if (event.key === keyName.enter && event.shiftKey) {
-      event.preventDefault();
-      setIsTyping(false);
-      setKey(Math.random());
-      splitLine(index, blockList, blockRef, noteId);
     }
 
     // 일반 backspace 클릭

--- a/src/app/(main)/note/[id]/_components/note-content/block/handler/handleMouseMove.ts
+++ b/src/app/(main)/note/[id]/_components/note-content/block/handler/handleMouseMove.ts
@@ -63,10 +63,13 @@ const handleMouseMove = (
     const windowSelection = window.getSelection();
     if (windowSelection) windowSelection.removeAllRanges();
   }
-  setSelection(prev => ({
-    ...prev,
-    end: { ...prev.end, offset: charIdx },
-  }));
+
+  if (charIdx !== selection.end.offset) {
+    setSelection(prev => ({
+      ...prev,
+      end: { ...prev.end, offset: charIdx },
+    }));
+  }
 
   // 첫 번째 블록에서
   if (index === selection.start.blockIndex && index === selection.end.blockIndex) {

--- a/src/app/(main)/note/[id]/_components/note-content/block/handler/handleMouseUp.ts
+++ b/src/app/(main)/note/[id]/_components/note-content/block/handler/handleMouseUp.ts
@@ -83,9 +83,9 @@ const handleMouseUp = (
     // 빈 블록일 때 클릭 한 블록에 focus
     // block의 타입마다 blockRef의 깊이가 달라서 type에 맞게 focus
     if (blockList[index].nodes.length === 1 && blockList[index].nodes[0].content === '') {
-      if (blockList[index].type === 'ul' || blockList[index].type === 'ol') {
+      if (blockList[index].type === 'UL' || blockList[index].type === 'OL') {
         (blockRef.current[index]?.parentNode?.parentNode?.parentNode as HTMLElement)?.focus();
-      } else if (blockList[index].type === 'quote') {
+      } else if (blockList[index].type === 'QUOTE') {
         (blockRef.current[index]?.parentNode?.parentNode as HTMLElement)?.focus();
       } else {
         (blockRef.current[index]?.parentNode as HTMLElement)?.focus();

--- a/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
+++ b/src/app/(main)/note/[id]/_components/note-content/note-content.tsx
@@ -471,7 +471,7 @@ const NoteContent = () => {
 
     setSelection(prev => ({
       ...prev,
-      end: { ...prev.end, blockId: blockList[index].id, blockIndex: index },
+      end: { ...prev.end, blockId: blocks[index].id, blockIndex: index },
     }));
 
     // 로컬 변수를 활용해 비동기적 함수 처리


### PR DESCRIPTION
## 📝 PR Description

- 셀렉션 시작 후 다시 되돌아 왔을 때, focus가 생기도록 수정
- span 에서 드래그 시작 시 mouseMove 시 포커스가 맨 앞으로 이동하던 문제 해결
- shift enter 로직을 enter 로직과 통일

---

## 🔍 Changes Made

- 셀렉션 시작 후 다시 되돌아 왔을 때, focus가 생기도록 수정
- span 에서 드래그 시작 시 mouseMove 시 포커스가 맨 앞으로 이동하던 문제 해결
- shift enter 로직을 enter 로직과 통일

---

## 🔄 Extra Comments

- mouseMove 시 setSelection이 계속하여 일어나 렌더링이 되어 포커스가 맨 앞으로 이동하던 문제를, 커서의 위치를 이용해 해결하였습니다.
- 미완성인 shift + enter 로직을 주석 처리 하였습니다.

---