### PR TITLE
feat: 사이드바에서 페이지 순서 맨 위로 변경

### DIFF
--- a/src/app/(main)/_components/sidebar/finder/finder-card.tsx
+++ b/src/app/(main)/_components/sidebar/finder/finder-card.tsx
@@ -76,6 +76,7 @@ const FinderCard = () => {
     parentId: string;
     order: number;
   } | null>(null);
+  const [isDragFirst, setIsDragFirst] = useState(false);
   const { data: noteList } = useSWR('noteList');
 
   const handleClick = async () => {
@@ -103,7 +104,7 @@ const FinderCard = () => {
       </div>
       <div className={noteContainer}>
         {noteList?.length ? (
-          noteList.map((note: INotes) => (
+          noteList.map((note: INotes, index: number) => (
             <NoteItem
               key={note.id}
               note={note}
@@ -112,6 +113,9 @@ const FinderCard = () => {
               setOpenedDropdownnoteId={setOpenedDropdownnoteId}
               draggingNoteInfo={draggingNoteInfo}
               setDraggingNoteInfo={setDraggingNoteInfo}
+              isDragFirst={isDragFirst}
+              setIsDragFirst={setIsDragFirst}
+              index={index}
             />
           ))
         ) : (


### PR DESCRIPTION
## 📝 PR Description

- 사이드바에서 페이지 순서 맨 위로 변경

---

## 🔍 Changes Made

- 사이드바에서 같은 높이의 가장 첫 페이지 윗쪽으로 드래그 앤 드롭 시 맨 위로 페이지 이동

---

**설명**: 이 항목에서는 코드의 주요 변경 사항을 나열하여 리뷰어가 코드 수정의 목적을 쉽게 파악할 수 있도록 합니다.
변경된 주요 로직이나 UI 수정 사항이 있다면 구체적으로 설명합니다.

---

## 📷 Demo


https://github.com/user-attachments/assets/2090cbb2-77d7-455d-b1a1-47e8b7b1a53b


---

**설명**: UI 변경 사항이 포함된 경우, 변경된 화면을 시각적으로 보여주기 위해 스크린샷이나 동영상을 첨부하면 도움이
됩니다. 리뷰어는 화면 변경 사항을 바로 확인할 수 있어 코드 리뷰가 더 효과적입니다.

---
